### PR TITLE
Fix some inefficient uses of %s literal

### DIFF
--- a/src/irdevices/airconditioners.ts
+++ b/src/irdevices/airconditioners.ts
@@ -1,5 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { CharacteristicValue, HAPStatus, PlatformAccessory, Service } from 'homebridge';
+import util from 'util';
 import { SwitchBotPlatform } from '../platform';
 import { DeviceURL, irdevice } from '../settings';
 
@@ -261,7 +262,7 @@ export class AirConditioner {
     this.CurrentARMode = this.CurrentMode || 1;
     this.CurrentARFanSpeed = this.CurrentFanSpeed || 1;
     this.ARActive = this.Active === 1 ? 'on' : 'off';
-    payload.parameter = '%s,%s,%s,%s', this.CurrentARTemp, this.CurrentARMode, this.CurrentARFanSpeed, this.ARActive;
+    payload.parameter = util.format('%s,%s,%s,%s', this.CurrentARTemp, this.CurrentARMode, this.CurrentARFanSpeed, this.ARActive);
 
 
     if (this.Active === 1) {

--- a/src/irdevices/airpurifiers.ts
+++ b/src/irdevices/airpurifiers.ts
@@ -1,5 +1,6 @@
 import { AxiosResponse } from 'axios';
 import { CharacteristicValue, HAPStatus, PlatformAccessory, Service } from 'homebridge';
+import util from 'util';
 import { SwitchBotPlatform } from '../platform';
 import { DeviceURL, irdevice } from '../settings';
 
@@ -159,7 +160,7 @@ export class AirPurifier {
     this.CurrentAPMode = this.CurrentMode || 1;
     this.CurrentAPFanSpeed = this.CurrentFanSpeed || 1;
     this.APActive = this.Active === 1 ? 'on' : 'off';
-    payload.parameter = '%s,%s,%s,%s', this.CurrentAPTemp, this.CurrentAPMode, this.CurrentAPFanSpeed, this.APActive;
+    payload.parameter = util.format('%s,%s,%s,%s', this.CurrentAPTemp, this.CurrentAPMode, this.CurrentAPFanSpeed, this.APActive);
 
     if (this.Active === 1) {
       if ((this.CurrentTemperature || 24) < (this.LastTemperature || 30)) {


### PR DESCRIPTION
If you use Logger by homebridge (like via `this.log.info`), it works as expected, because [it uses `util.format`](https://github.com/homebridge/homebridge/blob/master/src/logger.ts#L151). However, I found some codes with inefficient use of %s literal.

## Case `a = '%s,%s,%s,%s', b, c, d, e`

Let us assume that `b` is 'foo', `c` is 'bar', `d` is 'baz', and `e` is 'qux'. Though it seems you expected `a` to be `foo,bar,baz,qux`, the actual result is that `a` is `%s%s%s%s` (literally includes '%s'.)

There are several ways to achieve the expected behavior:

```
import util from 'util';
a = util.format('%s,%s,%s,%s', b, c, d, e)
```

```
a = `${b},${c},${d},${e}`
```

and in this case:

```
a = [b, c, d, e].join(',')
```

In this pull request, I applied the first solution because of the similar form to the original code, while you may like other.

I searched the whole code and the lines listed below were applicable:

* `src/irdevices/airconditioners.ts` L264
* `src/irdevices/airpurifiers.ts` L162

I fixed the both!

## Case `(a = b || c), '%s %s', d, e`

As well as the above case, this expression is meaningless; `'%s %s'`, `d`, and `e` are ignored. However, **I haven't fix them** because I couldn't understand what you intended to do.

I searched the whole code and the lines listed below were applicable.

* `src/devices/bots.ts` L80
* `src/devices/bots.ts` L84
* `src/devices/bulb.ts` L32
* `src/devices/contact.ts` L47
* `src/devices/curtains.ts` L76
* `src/devices/humidifiers.ts` L59
* `src/devices/humidifiers.ts` L114
* `src/devices/meters.ts` L60
* `src/devices/meters.ts` L89
* `src/devices/meters.ts` L120
* `src/devices/motion.ts` L47
* `src/devices/meters.ts` L60
* `src/devices/plugs.ts` L43
* `src/irdevices/airpurifiers.ts` L45
* `src/irdevices/cameras.ts` L35
* `src/irdevices/fans.ts` L38
* `src/irdevices/tvs.ts` L54
* `src/irdevices/tvs.ts` L89

---

P.S. Thanks for the great plugin. I can't live without this!