### PR TITLE
v1.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
+## [Version 1.2.3](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.3) (2021-11-24)
+
+## What's Changed
+* When BLE Connection isn't established, allow for OpenAPI to kick in if `openToken` is supplied.
+
+**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.2.2...v1.2.3
+
 ## [Version 1.2.2](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.2) (2021-11-24)
 
 ## What's Changed

--- a/src/devices/bots.ts
+++ b/src/devices/bots.ts
@@ -249,7 +249,7 @@ export class Bot {
       };
       // Wait 10 seconds
       return switchbot.wait(10000);
-    }).then(() => {
+    }).then(async () => {
       // Stop to monitor
       switchbot.stopScan();
       if (this.connected) {
@@ -257,6 +257,10 @@ export class Bot {
         this.updateHomeKitCharacteristics();
       } else {
         this.platform.log.error(`Bot: ${this.accessory.displayName} wasn't able to establish BLE Connection`);
+        if (this.platform.config.credentials?.openToken) {
+          this.platform.log.warn(`Bot: ${this.accessory.displayName} Using OpenAPI Connection`);
+          await this.openAPIRefreshStatus();
+        }
       }
     }).catch(async (e: any) => {
       this.platform.log.error(`Bot: ${this.accessory.displayName} failed refreshStatus with BLE Connection`);

--- a/src/devices/contact.ts
+++ b/src/devices/contact.ts
@@ -260,7 +260,7 @@ export class Contact {
       };
       // Wait 10 seconds
       return switchbot.wait(10000);
-    }).then(() => {
+    }).then(async () => {
       // Stop to monitor
       switchbot.stopScan();
       if (this.connected) {
@@ -268,6 +268,10 @@ export class Contact {
         this.updateHomeKitCharacteristics();
       } else {
         this.platform.log.error(`Contact Sensor: ${this.accessory.displayName} wasn't able to establish BLE Connection`);
+        if (this.platform.config.credentials?.openToken) {
+          this.platform.log.warn(`Contact Sensor: ${this.accessory.displayName} Using OpenAPI Connection`);
+          await this.openAPIRefreshStatus();
+        }
       }
     }).catch(async (e: any) => {
       this.platform.log.error(`Contact Sensor: ${this.accessory.displayName} failed refreshStatus with BLE Connection`);

--- a/src/devices/curtains.ts
+++ b/src/devices/curtains.ts
@@ -425,7 +425,7 @@ export class Curtain {
       };
       // Wait 10 seconds
       return switchbot.wait(10000);
-    }).then(() => {
+    }).then(async () => {
       // Stop to monitor
       switchbot.stopScan();
       if (this.connected) {
@@ -433,6 +433,10 @@ export class Curtain {
         this.updateHomeKitCharacteristics();
       } else {
         this.platform.log.error(`Curtain: ${this.accessory.displayName} wasn't able to establish BLE Connection`);
+        if (this.platform.config.credentials?.openToken) {
+          this.platform.log.warn(`Curtain: ${this.accessory.displayName} Using OpenAPI Connection`);
+          await this.openAPIRefreshStatus();
+        }
       }
     }).catch(async (e: any) => {
       this.platform.log.error(`Curtain: ${this.accessory.displayName} failed refreshStatus with BLE Connection`);

--- a/src/devices/humidifiers.ts
+++ b/src/devices/humidifiers.ts
@@ -327,7 +327,7 @@ export class Humidifier {
       };
       // Wait 10 seconds
       return switchbot.wait(10000);
-    }).then(() => {
+    }).then(async () => {
       // Stop to monitor
       switchbot.stopScan();
       if (this.connected) {
@@ -335,6 +335,10 @@ export class Humidifier {
         this.updateHomeKitCharacteristics();
       } else {
         this.platform.log.error(`Humidifier: ${this.accessory.displayName} wasn't able to establish BLE Connection`);
+        if (this.platform.config.credentials?.openToken) {
+          this.platform.log.warn(`Humidifier: ${this.accessory.displayName} Using OpenAPI Connection`);
+          await this.openAPIRefreshStatus();
+        }
       }
     }).catch(async (e: any) => {
       this.platform.log.error(`Humidifier: ${this.accessory.displayName} failed refreshStatus with BLE Connection`);

--- a/src/devices/meters.ts
+++ b/src/devices/meters.ts
@@ -284,7 +284,7 @@ export class Meter {
       };
       // Wait 10 seconds
       return switchbot.wait(10000);
-    }).then(() => {
+    }).then(async () => {
       // Stop to monitor
       switchbot.stopScan();
       if (this.connected) {
@@ -292,6 +292,10 @@ export class Meter {
         this.updateHomeKitCharacteristics();
       } else {
         this.platform.log.error(`Meter: ${this.accessory.displayName} wasn't able to establish BLE Connection`);
+        if (this.platform.config.credentials?.openToken) {
+          this.platform.log.warn(`Meter: ${this.accessory.displayName} Using OpenAPI Connection`);
+          await this.openAPIRefreshStatus();
+        }
       }
     }).catch(async (e: any) => {
       this.platform.log.error(`Meter: ${this.accessory.displayName} failed refreshStatus with BLE Connection`);

--- a/src/devices/motion.ts
+++ b/src/devices/motion.ts
@@ -197,7 +197,7 @@ export class Motion {
       };
       // Wait 10 seconds
       return switchbot.wait(10000);
-    }).then(() => {
+    }).then(async () => {
       // Stop to monitor
       switchbot.stopScan();
       if (this.connected) {
@@ -205,6 +205,10 @@ export class Motion {
         this.updateHomeKitCharacteristics();
       } else {
         this.platform.log.error(`Motion Sensor: ${this.accessory.displayName} wasn't able to establish BLE Connection`);
+        if (this.platform.config.credentials?.openToken) {
+          this.platform.log.warn(`Motion Sensor: ${this.accessory.displayName} Using OpenAPI Connection`);
+          await this.openAPIRefreshStatus();
+        }
       }
     }).catch(async (e: any) => {
       this.platform.log.error(`Motion Sensor: ${this.accessory.displayName} failed refreshStatus with BLE Connection`);


### PR DESCRIPTION
## [Version 1.2.3](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.3) (2021-11-24)

## What's Changed
* When BLE Connection isn't established, allow for OpenAPI to kick in if `openToken` is supplied.

**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.2.2...v1.2.3