### PR TITLE
v1.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
+## [Version 1.2.5](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.5) (2021-11-25)
+
+## What's Changed
+* Fixed Bug: Where `set_minLux` & `set_maxLux` config settings not effecting OpenAPI Lux.
+
+**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.2.4...v1.2.5
+
 ## [Version 1.2.4](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.4) (2021-11-24)
 
 ## What's Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@switchbot/homebridge-switchbot",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@switchbot/homebridge-switchbot",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "funding": [
         {
           "type": "Paypal",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge SwitchBot",
   "name": "@switchbot/homebridge-switchbot",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "The [Homebridge](https://homebridge.io) SwitchBot plugin allows you to access your [SwitchBot](https://www.switch-bot.com) device(s) from HomeKit.",
   "author": "SwitchBot <support@wondertechlabs.com> (https://github.com/SwitchBot)",
   "license": "ISC",

--- a/src/devices/curtains.ts
+++ b/src/devices/curtains.ts
@@ -373,14 +373,16 @@ export class Curtain {
         + ` TargetPosition: ${this.TargetPosition}, PositionState: ${this.PositionState},`);
 
       if (!this.device.curtain?.hide_lightsensor) {
+        this.set_minLux = this.minLux();
+        this.set_maxLux = this.maxLux();
         // Brightness
         switch (this.deviceStatus.body.brightness) {
           case 'dim':
-            this.CurrentAmbientLightLevel = 0.0001;
+            this.CurrentAmbientLightLevel = this.set_minLux;
             break;
           case 'bright':
           default:
-            this.CurrentAmbientLightLevel = 100000;
+            this.CurrentAmbientLightLevel = this.set_maxLux;
         }
         this.platform.debug(`Curtain: ${this.accessory.displayName} CurrentAmbientLightLevel: ${this.CurrentAmbientLightLevel}`);
       }


### PR DESCRIPTION
## [Version 1.2.5](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.5) (2021-11-25)

## What's Changed
* Fixed Bug: Where `set_minLux` & `set_maxLux` config settings not effecting OpenAPI Lux.

**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.2.4...v1.2.5