### PR TITLE
v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,12 @@ All notable changes to this project will be documented in this file. This projec
     * This will only Works in 3rd Party Home App, Like [Eve](https://apps.apple.com/us/app/eve-for-homekit/id917695792) or [Home+ 5](https://apps.apple.com/us/app/home-5/id995994352)
 * Add option to Hide Motion Sensor's Light Sensor.
 * Add option to Set Motion Sensor's Light Sensor `set_minLux` and `set_maxLux`.
+* Fixed Bug: Where BLE config would show for devices that don't support BLE.
 * Fixed Bug: Contact Sensors's Motion Sensor and Light Sensor showing undefined values.
 * Fixed Bug: Motion Sensors's Light Sensor showing undefined values.
 * Fixed Bug: Battery Service wouldn't be removed from Curtain, Contact Sensor, or Motion Sensor when switching from BLE to OpenAPI.
 * Enhancments: Made some improvemnt on the switch from BLE to OpenAPI when BLE connection fails.
+* Enhancments: Made Optional Switchbot Device Settings and Optional IR Device Settings more managable by using Tabs.
 * Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.7.0...v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ All notable changes to this project will be documented in this file. This projec
 ## What's Changed
 * Added option to display Bot a Stateful Programmable Switch.
     * This will only Works in 3rd Party Home App, Like [Eve](https://apps.apple.com/us/app/eve-for-homekit/id917695792) or [Home+ 5](https://apps.apple.com/us/app/home-5/id995994352)
+* Add option to Hide Motion Sensor's Light Sensor.
+* Add option to Set Motion Sensor's Light Sensor `set_minLux` and `set_maxLux`.
 * Fixed Bug: Contact Sensors's Motion Sensor and Light Sensor showing undefined values.
+* Fixed Bug: Motion Sensors's Light Sensor showing undefined values.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.7.0...v1.7.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
-## [Beta - Version 1.7.1](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.7.1) (2022-01-00)
+## [Beta - Version 1.8.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.8.0) (2022-01-XX)
 
 ## What's Changed
 * Added option to display Bot a Stateful Programmable Switch.
@@ -11,8 +11,11 @@ All notable changes to this project will be documented in this file. This projec
 * Add option to Set Motion Sensor's Light Sensor `set_minLux` and `set_maxLux`.
 * Fixed Bug: Contact Sensors's Motion Sensor and Light Sensor showing undefined values.
 * Fixed Bug: Motion Sensors's Light Sensor showing undefined values.
+* Fixed Bug: Battery Service wouldn't be removed from Curtain, Contact Sensor, or Motion Sensor when switching from BLE to OpenAPI.
+* Enhancments: Made some improvemnt on the switch from BLE to OpenAPI when BLE connection fails.
+* Housekeeping and updated dependencies.
 
-**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.7.0...v1.7.1
+**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.7.0...v1.8.0
 
 ## [Version 1.7.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.7.0) (2022-01-05)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
+## [Beta - Version 1.7.1](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.7.1) (2022-01-00)
+
+## What's Changed
+* Added option to display Bot a Stateful Programmable Switch.
+    * This will only Works in 3rd Party Home App, Like [Eve](https://apps.apple.com/us/app/eve-for-homekit/id917695792) or [Home+ 5](https://apps.apple.com/us/app/home-5/id995994352)
+* Fixed Bug: Contact Sensors's Motion Sensor and Light Sensor showing undefined values.
+
+**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.7.0...v1.7.1
+
 ## [Version 1.7.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.7.0) (2022-01-05)
 
 ## What's Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ All notable changes to this project will be documented in this file. This projec
 * Fixed Bug: Battery Service wouldn't be removed from Curtain, Contact Sensor, or Motion Sensor when switching from BLE to OpenAPI.
 * Enhancments: Made some improvemnt on the switch from BLE to OpenAPI when BLE connection fails.
 * Enhancments: Made Optional Switchbot Device Settings and Optional IR Device Settings more managable by using Tabs.
+* Change: Changed Curtain `refreshRate` to `updateRate`.
+    * You will have to update your config for it to pickup the new `updateRate`.
 * Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.7.0...v1.8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
-## [Beta - Version 1.8.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.8.0) (2022-01-XX)
+## [Version 1.8.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.8.0) (2022-01-14)
 
 ## What's Changed
 * Added option to display Bot a Stateful Programmable Switch.

--- a/config.schema.json
+++ b/config.schema.json
@@ -225,6 +225,12 @@
                           ]
                         },
                         {
+                          "title": "Stateful Programmable Switch (Only Works in 3rd Party Home Apps)",
+                          "enum": [
+                            "stateful"
+                          ]
+                        },
+                        {
                           "title": "Switch",
                           "enum": [
                             "switch"
@@ -365,6 +371,22 @@
                       "type": "boolean",
                       "condition": {
                         "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Contact Sensor' && model.options.devices[arrayIndices].deviceId);"
+                      }
+                    },
+                    "set_minlux": {
+                      "title": "Set Min Lux",
+                      "type": "number",
+                      "placeholder": "1",
+                      "condition": {
+                        "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Contact Sensor' && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].contact.hide_lightsensor);"
+                      }
+                    },
+                    "set_maxlux": {
+                      "title": "Set Max Lux",
+                      "type": "number",
+                      "placeholder": "6001",
+                      "condition": {
+                        "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Contact Sensor' && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].contact.hide_lightsensor);"
                       }
                     },
                     "hide_motionsensor": {
@@ -850,6 +872,8 @@
             "options.devices[].curtain.set_minlux",
             "options.devices[].curtain.set_maxlux",
             "options.devices[].contact.hide_lightsensor",
+            "options.devices[].contact.set_minlux",
+            "options.devices[].contact.set_maxlux",
             "options.devices[].contact.hide_motionsensor",
             "options.devices[].colorbulb.set_minStep",
             "options.devices[].colorbulb.adaptiveLightingShift",

--- a/config.schema.json
+++ b/config.schema.json
@@ -398,6 +398,34 @@
                     }
                   }
                 },
+                "motion": {
+                  "type": "object",
+                  "properties": {
+                    "hide_lightsensor": {
+                      "title": "Hide Motion Sensor's Light Sensor",
+                      "type": "boolean",
+                      "condition": {
+                        "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Motion Sensor' && model.options.devices[arrayIndices].deviceId);"
+                      }
+                    },
+                    "set_minlux": {
+                      "title": "Set Min Lux",
+                      "type": "number",
+                      "placeholder": "1",
+                      "condition": {
+                        "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Motion Sensor' && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].motion.hide_lightsensor);"
+                      }
+                    },
+                    "set_maxlux": {
+                      "title": "Set Max Lux",
+                      "type": "number",
+                      "placeholder": "6001",
+                      "condition": {
+                        "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Motion Sensor' && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].motion.hide_lightsensor);"
+                      }
+                    }
+                  }
+                },
                 "colorbulb": {
                   "type": "object",
                   "properties": {
@@ -875,6 +903,9 @@
             "options.devices[].contact.set_minlux",
             "options.devices[].contact.set_maxlux",
             "options.devices[].contact.hide_motionsensor",
+            "options.devices[].motion.hide_lightsensor",
+            "options.devices[].motion.set_minlux",
+            "options.devices[].motion.set_maxlux",
             "options.devices[].colorbulb.set_minStep",
             "options.devices[].colorbulb.adaptiveLightingShift",
             "options.devices[].refreshRate",

--- a/config.schema.json
+++ b/config.schema.json
@@ -11,8 +11,7 @@
       "name": {
         "type": "string",
         "title": "Name",
-        "default": "SwitchBot",
-        "required": true
+        "default": "SwitchBot"
       },
       "credentials": {
         "type": "object",
@@ -20,7 +19,6 @@
           "openToken": {
             "title": "Token",
             "type": "string",
-            "required": true,
             "x-schema-form": {
               "type": "password"
             }
@@ -28,10 +26,13 @@
           "notice": {
             "title": "Notice",
             "type": "string",
-            "required": true,
             "default": "Keep your token a secret!"
           }
-        }
+        },
+        "required": [
+          "openToken",
+          "notice"
+        ]
       },
       "options": {
         "type": "object",
@@ -141,7 +142,7 @@
                   }
                 },
                 "scanDuration": {
-                  "title": "Scan Duration (Default is 1 Second)",
+                  "title": "BLE Scan Duration (Default is 1 Second)",
                   "type": "number",
                   "placeholder": 1,
                   "condition": {
@@ -485,8 +486,14 @@
                     "functionBody": "return (model.options && model.options.devices && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType);"
                   }
                 }
-              }
-            }
+              },
+              "required": [
+                "deviceId",
+                "configDeviceType",
+                "configDeviceName"
+              ]
+            },
+            "uniqueItems": true
           },
           "irdevices": {
             "type": "array",
@@ -804,11 +811,16 @@
                     }
                   ],
                   "condition": {
-                    "functionBody": "return (model.options && model.options.irdevices && model.options.irdevices[arrayIndices].deviceId && !model.options.irdevices[arrayIndices].hide_device);"
+                    "functionBody": "return (model.options && model.options.irdevices && model.options.irdevices[arrayIndices].deviceId && !model.options.irdevices[arrayIndices].hide_device && model.options.irdevices[arrayIndices].configRemoteType);"
                   }
                 }
-              }
-            }
+              },
+              "required": [
+                "deviceId",
+                "configRemoteType"
+              ]
+            },
+            "uniqueItems": true
           },
           "refreshRate": {
             "title": "Refresh Rate",
@@ -849,7 +861,10 @@
           }
         }
       }
-    }
+    },
+    "required": [
+      "name"
+    ]
   },
   "layout": [
     {
@@ -862,20 +877,19 @@
       ]
     },
     {
-      "key": "options.devices",
-      "notitle": false,
-      "add": "Add Another Device",
       "type": "fieldset",
       "title": "Optional SwitchBot Device Settings",
       "expandable": true,
       "expanded": false,
-      "orderable": false,
-      "buttonText": "Add Device",
       "items": [
         {
-          "type": "div",
-          "displayFlex": true,
-          "flex-direction": "column",
+          "key": "options.devices",
+          "notitle": false,
+          "type": "tabarray",
+          "title": "{{ value.configDeviceName || value.deviceId || 'New SwitchBot Device' }}",
+          "expandable": true,
+          "expanded": false,
+          "orderable": false,
           "items": [
             "options.devices[].configDeviceName",
             "options.devices[].deviceId",
@@ -915,20 +929,19 @@
       ]
     },
     {
-      "key": "options.irdevices",
-      "notitle": false,
-      "add": "Add Another IR Device",
       "type": "fieldset",
       "title": "Optional IR Device Settings",
       "expandable": true,
       "expanded": false,
-      "orderable": false,
-      "buttonText": "Add IR Device",
       "items": [
         {
-          "type": "div",
-          "displayFlex": true,
-          "flex-direction": "column",
+          "key": "options.irdevices",
+          "notitle": false,
+          "type": "tabarray",
+          "title": "{{ value.configDeviceName || value.deviceId || 'New IR Device' }}",
+          "expandable": true,
+          "expanded": false,
+          "orderable": false,
           "items": [
             "options.irdevices[].deviceId",
             "options.irdevices[].hide_device",

--- a/config.schema.json
+++ b/config.schema.json
@@ -137,7 +137,7 @@
                   "title": "Enable Bluetooth Low Energy (BLE) Connection",
                   "type": "boolean",
                   "condition": {
-                    "functionBody": "return (model.options && model.options.devices && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].hide_device);"
+                    "functionBody": "return (model.options && model.options.devices && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].hide_device && (model.options.devices[arrayIndices].configDeviceType === 'Humidifier' || model.options.devices[arrayIndices].configDeviceType === 'Meter' || model.options.devices[arrayIndices].configDeviceType === 'Curtain' || model.options.devices[arrayIndices].configDeviceType === 'Bot'));"
                   }
                 },
                 "scanDuration": {
@@ -455,7 +455,7 @@
                   "placeholder": 360,
                   "description": "Indicates the number of seconds between polls of SwitchBot API.",
                   "condition": {
-                    "functionBody": "return (model.options && model.options.devices && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].hide_device);"
+                    "functionBody": "return (model.options && model.options.devices && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType);"
                   }
                 },
                 "logging": {
@@ -482,7 +482,7 @@
                     }
                   ],
                   "condition": {
-                    "functionBody": "return (model.options && model.options.devices && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].hide_device);"
+                    "functionBody": "return (model.options && model.options.devices && model.options.devices[arrayIndices].deviceId && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType);"
                   }
                 }
               }
@@ -880,10 +880,10 @@
             "options.devices[].configDeviceName",
             "options.devices[].deviceId",
             "options.devices[].hide_device",
+            "options.devices[].configDeviceType",
             "options.devices[].offline",
             "options.devices[].ble",
             "options.devices[].scanDuration",
-            "options.devices[].configDeviceType",
             "options.devices[].bot.mode",
             "options.devices[].bot.deviceType",
             "options.devices[].bot.doublePress",

--- a/config.schema.json
+++ b/config.schema.json
@@ -322,8 +322,8 @@
                         "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Curtain' && model.options.devices[arrayIndices].deviceId);"
                       }
                     },
-                    "refreshRate": {
-                      "title": "Curtain Refresh Rate",
+                    "updateRate": {
+                      "title": "Curtain Update Rate",
                       "type": "number",
                       "minimum": 1,
                       "placeholder": 5,
@@ -908,7 +908,7 @@
             "options.devices[].curtain.set_minStep",
             "options.devices[].curtain.set_min",
             "options.devices[].curtain.set_max",
-            "options.devices[].curtain.refreshRate",
+            "options.devices[].curtain.updateRate",
             "options.devices[].curtain.disable_group",
             "options.devices[].curtain.hide_lightsensor",
             "options.devices[].curtain.set_minlux",

--- a/config.schema.json
+++ b/config.schema.json
@@ -53,7 +53,7 @@
                   "type": "string",
                   "placeholder": "SwitchBot",
                   "condition": {
-                    "functionBody": "return (model.options && model.options.devices && model.options.devices[arrayIndices].deviceId && model.options.devices[arrayIndices].ble && !model.options.devices[arrayIndices].hide_device);"
+                    "functionBody": "return (model.options && model.options.devices && model.options.devices[arrayIndices].deviceId);"
                   }
                 },
                 "hide_device": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@switchbot/homebridge-switchbot",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@switchbot/homebridge-switchbot",
-      "version": "1.7.0",
+      "version": "1.8.0",
       "funding": [
         {
           "type": "Paypal",
@@ -1769,9 +1769,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
-      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -4235,9 +4235,9 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.0.tgz",
-      "integrity": "sha512-OE85RadmCYZJzYgIcWd2Qum/wJ20WwY5Z6Bfv5FeBPU46uPD01s3pe2LNoi0etmr83ibsFidC0ZiKXmPY5UpmQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
+      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -6534,9 +6534,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
-      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -8387,9 +8387,9 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.0.tgz",
-      "integrity": "sha512-OE85RadmCYZJzYgIcWd2Qum/wJ20WwY5Z6Bfv5FeBPU46uPD01s3pe2LNoi0etmr83ibsFidC0ZiKXmPY5UpmQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.1.tgz",
+      "integrity": "sha512-pMR7hBVUUGI7PMA37m2ofIdQCsomVnas+Jn5UPGAHQ+/LlwKm/aTLJHdasmHRzlfeZwHiAOaRSo2rbBDm3nNUQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,12 +21,12 @@
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^0.0.19",
         "axios": "^0.24.0",
-        "rxjs": "^7.5.1"
+        "rxjs": "^7.5.2"
       },
       "devDependencies": {
         "@types/node": "^17.0.8",
-        "@typescript-eslint/eslint-plugin": "^5.9.0",
-        "@typescript-eslint/parser": "^5.9.0",
+        "@typescript-eslint/eslint-plugin": "^5.9.1",
+        "@typescript-eslint/parser": "^5.9.1",
         "eslint": "^8.6.0",
         "homebridge": "^1.3.9",
         "nodemon": "^2.0.15",
@@ -421,14 +421,14 @@
       "dev": true
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.0.tgz",
-      "integrity": "sha512-qT4lr2jysDQBQOPsCCvpPUZHjbABoTJW8V9ZzIYKHMfppJtpdtzszDYsldwhFxlhvrp7aCHeXD1Lb9M1zhwWwQ==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.1.tgz",
+      "integrity": "sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.9.0",
-        "@typescript-eslint/scope-manager": "5.9.0",
-        "@typescript-eslint/type-utils": "5.9.0",
+        "@typescript-eslint/experimental-utils": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.9.1",
+        "@typescript-eslint/type-utils": "5.9.1",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -454,15 +454,15 @@
       }
     },
     "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.0.tgz",
-      "integrity": "sha512-ZnLVjBrf26dn7ElyaSKa6uDhqwvAi4jBBmHK1VxuFGPRAxhdi18ubQYSGA7SRiFiES3q9JiBOBHEBStOFkwD2g==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
+      "integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
       "dev": true,
       "dependencies": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.9.0",
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/typescript-estree": "5.9.0",
+        "@typescript-eslint/scope-manager": "5.9.1",
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/typescript-estree": "5.9.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -478,14 +478,14 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.0.tgz",
-      "integrity": "sha512-/6pOPz8yAxEt4PLzgbFRDpZmHnXCeZgPDrh/1DaVKOjvn/UPMlWhbx/gA96xRi2JxY1kBl2AmwVbyROUqys5xQ==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.1.tgz",
+      "integrity": "sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/scope-manager": "5.9.0",
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/typescript-estree": "5.9.0",
+        "@typescript-eslint/scope-manager": "5.9.1",
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/typescript-estree": "5.9.1",
         "debug": "^4.3.2"
       },
       "engines": {
@@ -505,13 +505,13 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.0.tgz",
-      "integrity": "sha512-DKtdIL49Qxk2a8icF6whRk7uThuVz4A6TCXfjdJSwOsf+9ree7vgQWcx0KOyCdk0i9ETX666p4aMhrRhxhUkyg==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
+      "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/visitor-keys": "5.9.0"
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/visitor-keys": "5.9.1"
       },
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -522,12 +522,12 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.0.tgz",
-      "integrity": "sha512-uVCb9dJXpBrK1071ri5aEW7ZHdDHAiqEjYznF3HSSvAJXyrkxGOw2Ejibz/q6BXdT8lea8CMI0CzKNFTNI6TEQ==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.1.tgz",
+      "integrity": "sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "5.9.0",
+        "@typescript-eslint/experimental-utils": "5.9.1",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       },
@@ -548,9 +548,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.0.tgz",
-      "integrity": "sha512-mWp6/b56Umo1rwyGCk8fPIzb9Migo8YOniBGPAQDNC6C52SeyNGN4gsVwQTAR+RS2L5xyajON4hOLwAGwPtUwg==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
+      "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
       "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -561,13 +561,13 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.0.tgz",
-      "integrity": "sha512-kxo3xL2mB7XmiVZcECbaDwYCt3qFXz99tBSuVJR4L/sR7CJ+UNAPrYILILktGj1ppfZ/jNt/cWYbziJUlHl1Pw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
+      "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/visitor-keys": "5.9.0",
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/visitor-keys": "5.9.1",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -588,12 +588,12 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.0.tgz",
-      "integrity": "sha512-6zq0mb7LV0ThExKlecvpfepiB+XEtFv/bzx7/jKSgyXTFD7qjmSu1FoiS0x3OZaiS+UIXpH2vd9O89f02RCtgw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
+      "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
       "dev": true,
       "dependencies": {
-        "@typescript-eslint/types": "5.9.0",
+        "@typescript-eslint/types": "5.9.1",
         "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
@@ -1769,9 +1769,9 @@
       "dev": true
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
+      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
       "dev": true,
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -1781,7 +1781,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-glob/node_modules/glob-parent": {
@@ -1898,9 +1898,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A==",
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==",
       "funding": [
         {
           "type": "individual",
@@ -2144,16 +2144,16 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -2306,9 +2306,9 @@
       }
     },
     "node_modules/hosted-git-info": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
@@ -4380,9 +4380,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.1.tgz",
-      "integrity": "sha512-KExVEeZWxMZnZhUZtsJcFwz8IvPvgu4G2Z2QyqjZQzUGr32KDYuSxrEYO4w3tFFNbfLozcrKUTvTPi+E9ywJkQ==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.2.tgz",
+      "integrity": "sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -5538,14 +5538,14 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.0.tgz",
-      "integrity": "sha512-qT4lr2jysDQBQOPsCCvpPUZHjbABoTJW8V9ZzIYKHMfppJtpdtzszDYsldwhFxlhvrp7aCHeXD1Lb9M1zhwWwQ==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.9.1.tgz",
+      "integrity": "sha512-Xv9tkFlyD4MQGpJgTo6wqDqGvHIRmRgah/2Sjz1PUnJTawjHWIwBivUE9x0QtU2WVii9baYgavo/bHjrZJkqTw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "5.9.0",
-        "@typescript-eslint/scope-manager": "5.9.0",
-        "@typescript-eslint/type-utils": "5.9.0",
+        "@typescript-eslint/experimental-utils": "5.9.1",
+        "@typescript-eslint/scope-manager": "5.9.1",
+        "@typescript-eslint/type-utils": "5.9.1",
         "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
@@ -5555,66 +5555,66 @@
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.0.tgz",
-      "integrity": "sha512-ZnLVjBrf26dn7ElyaSKa6uDhqwvAi4jBBmHK1VxuFGPRAxhdi18ubQYSGA7SRiFiES3q9JiBOBHEBStOFkwD2g==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-5.9.1.tgz",
+      "integrity": "sha512-cb1Njyss0mLL9kLXgS/eEY53SZQ9sT519wpX3i+U457l2UXRDuo87hgKfgRazmu9/tQb0x2sr3Y0yrU+Zz0y+w==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.9",
-        "@typescript-eslint/scope-manager": "5.9.0",
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/typescript-estree": "5.9.0",
+        "@typescript-eslint/scope-manager": "5.9.1",
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/typescript-estree": "5.9.1",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.0.tgz",
-      "integrity": "sha512-/6pOPz8yAxEt4PLzgbFRDpZmHnXCeZgPDrh/1DaVKOjvn/UPMlWhbx/gA96xRi2JxY1kBl2AmwVbyROUqys5xQ==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.9.1.tgz",
+      "integrity": "sha512-PLYO0AmwD6s6n0ZQB5kqPgfvh73p0+VqopQQLuNfi7Lm0EpfKyDalchpVwkE+81k5HeiRrTV/9w1aNHzjD7C4g==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/scope-manager": "5.9.0",
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/typescript-estree": "5.9.0",
+        "@typescript-eslint/scope-manager": "5.9.1",
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/typescript-estree": "5.9.1",
         "debug": "^4.3.2"
       }
     },
     "@typescript-eslint/scope-manager": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.0.tgz",
-      "integrity": "sha512-DKtdIL49Qxk2a8icF6whRk7uThuVz4A6TCXfjdJSwOsf+9ree7vgQWcx0KOyCdk0i9ETX666p4aMhrRhxhUkyg==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.9.1.tgz",
+      "integrity": "sha512-8BwvWkho3B/UOtzRyW07ffJXPaLSUKFBjpq8aqsRvu6HdEuzCY57+ffT7QoV4QXJXWSU1+7g3wE4AlgImmQ9pQ==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/visitor-keys": "5.9.0"
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/visitor-keys": "5.9.1"
       }
     },
     "@typescript-eslint/type-utils": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.0.tgz",
-      "integrity": "sha512-uVCb9dJXpBrK1071ri5aEW7ZHdDHAiqEjYznF3HSSvAJXyrkxGOw2Ejibz/q6BXdT8lea8CMI0CzKNFTNI6TEQ==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.9.1.tgz",
+      "integrity": "sha512-tRSpdBnPRssjlUh35rE9ug5HrUvaB9ntREy7gPXXKwmIx61TNN7+l5YKgi1hMKxo5NvqZCfYhA5FvyuJG6X6vg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "5.9.0",
+        "@typescript-eslint/experimental-utils": "5.9.1",
         "debug": "^4.3.2",
         "tsutils": "^3.21.0"
       }
     },
     "@typescript-eslint/types": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.0.tgz",
-      "integrity": "sha512-mWp6/b56Umo1rwyGCk8fPIzb9Migo8YOniBGPAQDNC6C52SeyNGN4gsVwQTAR+RS2L5xyajON4hOLwAGwPtUwg==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.9.1.tgz",
+      "integrity": "sha512-SsWegWudWpkZCwwYcKoDwuAjoZXnM1y2EbEerTHho19Hmm+bQ56QG4L4jrtCu0bI5STaRTvRTZmjprWlTw/5NQ==",
       "dev": true
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.0.tgz",
-      "integrity": "sha512-kxo3xL2mB7XmiVZcECbaDwYCt3qFXz99tBSuVJR4L/sR7CJ+UNAPrYILILktGj1ppfZ/jNt/cWYbziJUlHl1Pw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.9.1.tgz",
+      "integrity": "sha512-gL1sP6A/KG0HwrahVXI9fZyeVTxEYV//6PmcOn1tD0rw8VhUWYeZeuWHwwhnewnvEMcHjhnJLOBhA9rK4vmb8A==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.9.0",
-        "@typescript-eslint/visitor-keys": "5.9.0",
+        "@typescript-eslint/types": "5.9.1",
+        "@typescript-eslint/visitor-keys": "5.9.1",
         "debug": "^4.3.2",
         "globby": "^11.0.4",
         "is-glob": "^4.0.3",
@@ -5623,12 +5623,12 @@
       }
     },
     "@typescript-eslint/visitor-keys": {
-      "version": "5.9.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.0.tgz",
-      "integrity": "sha512-6zq0mb7LV0ThExKlecvpfepiB+XEtFv/bzx7/jKSgyXTFD7qjmSu1FoiS0x3OZaiS+UIXpH2vd9O89f02RCtgw==",
+      "version": "5.9.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.9.1.tgz",
+      "integrity": "sha512-Xh37pNz9e9ryW4TVdwiFzmr4hloty8cFj8GTWMXh3Z8swGwyQWeCcNgF0hm6t09iZd6eiZmIf4zHedQVP6TVtg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/types": "5.9.0",
+        "@typescript-eslint/types": "5.9.1",
         "eslint-visitor-keys": "^3.0.0"
       }
     },
@@ -6534,9 +6534,9 @@
       "dev": true
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.10.tgz",
+      "integrity": "sha512-s9nFhFnvR63wls6/kM88kQqDhMu0AfdjqouE2l5GVQPbqLgyFjjU5ry/r2yKsJxpb9Py1EYNqieFrmMaX4v++A==",
       "dev": true,
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
@@ -6641,9 +6641,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "foreach": {
       "version": "2.0.5",
@@ -6811,16 +6811,16 @@
       }
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dev": true,
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
     },
@@ -6931,9 +6931,9 @@
       }
     },
     "hosted-git-info": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.0.2.tgz",
-      "integrity": "sha512-c9OGXbZ3guC/xOlCg1Ci/VgWlwsqDv1yMQL1CWqXDL0hDjXuNcq0zuR4xqPSuasI3kqFDhqSyTjREz5gzq0fXg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
+      "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
       "dev": true,
       "requires": {
         "lru-cache": "^6.0.0"
@@ -8478,9 +8478,9 @@
       }
     },
     "rxjs": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.1.tgz",
-      "integrity": "sha512-KExVEeZWxMZnZhUZtsJcFwz8IvPvgu4G2Z2QyqjZQzUGr32KDYuSxrEYO4w3tFFNbfLozcrKUTvTPi+E9ywJkQ==",
+      "version": "7.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.2.tgz",
+      "integrity": "sha512-PwDt186XaL3QN5qXj/H9DGyHhP3/RYYgZZwqBv9Tv8rsAaiwFH1IsJJlcgD37J7UW5a6O67qX0KWKS3/pu0m4w==",
       "requires": {
         "tslib": "^2.1.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
       },
       "engines": {
         "homebridge": "^1.3.9",
-        "node": "^14.18.2 || ^16.13.1"
+        "node": "^14.18.3 || ^16.13.2"
       },
       "optionalDependencies": {
         "node-switchbot": "^1.1.2"
@@ -4235,9 +4235,9 @@
       }
     },
     "node_modules/regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.0.tgz",
+      "integrity": "sha512-OE85RadmCYZJzYgIcWd2Qum/wJ20WwY5Z6Bfv5FeBPU46uPD01s3pe2LNoi0etmr83ibsFidC0ZiKXmPY5UpmQ==",
       "dev": true,
       "dependencies": {
         "call-bind": "^1.0.2",
@@ -8387,9 +8387,9 @@
       }
     },
     "regexp.prototype.flags": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.3.1.tgz",
-      "integrity": "sha512-JiBdRBq91WlY7uRJ0ds7R+dU02i6LKi8r3BuQhNXn+kmeLN+EfHhfjqMRis1zJxnlu88hq/4dx0P2OP3APRTOA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.4.0.tgz",
+      "integrity": "sha512-OE85RadmCYZJzYgIcWd2Qum/wJ20WwY5Z6Bfv5FeBPU46uPD01s3pe2LNoi0etmr83ibsFidC0ZiKXmPY5UpmQ==",
       "dev": true,
       "requires": {
         "call-bind": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^0.0.19",
     "axios": "^0.24.0",
-    "rxjs": "^7.5.1"
+    "rxjs": "^7.5.2"
   },
   "devDependencies": {
     "@types/node": "^17.0.8",
-    "@typescript-eslint/eslint-plugin": "^5.9.0",
-    "@typescript-eslint/parser": "^5.9.0",
+    "@typescript-eslint/eslint-plugin": "^5.9.1",
+    "@typescript-eslint/parser": "^5.9.1",
     "eslint": "^8.6.0",
     "homebridge": "^1.3.9",
     "nodemon": "^2.0.15",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "engines": {
     "homebridge": "^1.3.9",
-    "node": "^14.18.2 || ^16.13.1"
+    "node": "^14.18.3 || ^16.13.2"
   },
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge SwitchBot",
   "name": "@switchbot/homebridge-switchbot",
-  "version": "1.7.0",
+  "version": "1.8.0",
   "description": "The [Homebridge](https://homebridge.io) SwitchBot plugin allows you to access your [SwitchBot](https://www.switch-bot.com) device(s) from HomeKit.",
   "author": "SwitchBot <support@wondertechlabs.com> (https://github.com/SwitchBot)",
   "license": "ISC",

--- a/src/devices/bots.ts
+++ b/src/devices/bots.ts
@@ -23,6 +23,7 @@ export class Bot {
   private batteryService?: Service;
   private garageDoorService?: Service;
   private windowCoveringService?: Service;
+  private statefulProgrammableSwitchService?: Service;
 
 
   // Characteristic Values
@@ -110,6 +111,7 @@ export class Bot {
       this.removeWindowService(accessory);
       this.removeGarageDoorService(accessory);
       this.removeWindowCoveringService(accessory);
+      this.removeStatefulProgrammableSwitchService(accessory);
 
       // Add switchService
       (this.switchService =
@@ -128,6 +130,7 @@ export class Bot {
       this.removeSwitchService(accessory);
       this.removeWindowService(accessory);
       this.removeWindowCoveringService(accessory);
+      this.removeStatefulProgrammableSwitchService(accessory);
 
       // Add switchService
       (this.garageDoorService =
@@ -147,6 +150,7 @@ export class Bot {
       this.removeWindowService(accessory);
       this.removeGarageDoorService(accessory);
       this.removeWindowCoveringService(accessory);
+      this.removeStatefulProgrammableSwitchService(accessory);
 
       // Add switchService
       (this.doorService =
@@ -172,6 +176,7 @@ export class Bot {
       this.removeSwitchService(accessory);
       this.removeGarageDoorService(accessory);
       this.removeWindowCoveringService(accessory);
+      this.removeStatefulProgrammableSwitchService(accessory);
 
       // Add switchService
       (this.windowService =
@@ -197,6 +202,7 @@ export class Bot {
       this.removeSwitchService(accessory);
       this.removeWindowService(accessory);
       this.removeGarageDoorService(accessory);
+      this.removeStatefulProgrammableSwitchService(accessory);
 
       // Add switchService
       (this.windowCoveringService =
@@ -222,6 +228,7 @@ export class Bot {
       this.removeWindowService(accessory);
       this.removeGarageDoorService(accessory);
       this.removeWindowCoveringService(accessory);
+      this.removeStatefulProgrammableSwitchService(accessory);
 
       // Add switchService
       (this.lockService =
@@ -240,6 +247,7 @@ export class Bot {
       this.removeWindowService(accessory);
       this.removeGarageDoorService(accessory);
       this.removeWindowCoveringService(accessory);
+      this.removeStatefulProgrammableSwitchService(accessory);
 
       // Add switchService
       (this.faucetService =
@@ -258,6 +266,7 @@ export class Bot {
       this.removeWindowService(accessory);
       this.removeGarageDoorService(accessory);
       this.removeWindowCoveringService(accessory);
+      this.removeStatefulProgrammableSwitchService(accessory);
 
       // Add switchService
       (this.fanService =
@@ -267,6 +276,26 @@ export class Bot {
 
       this.fanService.setCharacteristic(this.platform.Characteristic.Name, accessory.displayName);
       this.fanService.getCharacteristic(this.platform.Characteristic.On).onSet(this.handleOnSet.bind(this));
+    } else if (device.bot?.deviceType === 'stateful') {
+      this.removeFanService(accessory);
+      this.removeLockService(accessory);
+      this.removeDoorService(accessory);
+      this.removeFaucetService(accessory);
+      this.removeOutletService(accessory);
+      this.removeSwitchService(accessory);
+      this.removeWindowService(accessory);
+      this.removeGarageDoorService(accessory);
+      this.removeWindowCoveringService(accessory);
+
+      // Add switchService
+      (this.statefulProgrammableSwitchService =
+        accessory.getService(this.platform.Service.StatefulProgrammableSwitch) ||
+        accessory.addService(this.platform.Service.StatefulProgrammableSwitch)), `${accessory.displayName} Stateful Programmable Switch`;
+      this.infoLog(`Bot: ${accessory.displayName} Displaying as Stateful Programmable Switch`);
+
+      this.statefulProgrammableSwitchService.setCharacteristic(this.platform.Characteristic.Name, accessory.displayName);
+      this.statefulProgrammableSwitchService.getCharacteristic(this.platform.Characteristic.ProgrammableSwitchOutputState)
+        .onSet(this.handleOnSet.bind(this));
     } else {
       this.removeFanService(accessory);
       this.removeLockService(accessory);
@@ -276,6 +305,7 @@ export class Bot {
       this.removeWindowService(accessory);
       this.removeGarageDoorService(accessory);
       this.removeWindowCoveringService(accessory);
+      this.removeStatefulProgrammableSwitchService(accessory);
 
       // Add outletService
       (this.outletService =
@@ -408,6 +438,15 @@ export class Bot {
     accessory.removeService(this.windowCoveringService!);
   }
 
+  public removeStatefulProgrammableSwitchService(accessory: PlatformAccessory) {
+    // If statefulProgrammableSwitchService still pressent, then remove first
+    this.statefulProgrammableSwitchService = this.accessory.getService(this.platform.Service.StatefulProgrammableSwitch);
+    if (this.statefulProgrammableSwitchService) {
+      this.warnLog(`Bot: ${accessory.displayName} Removing Leftover Stateful Programmable Switch Service`);
+    }
+    accessory.removeService(this.statefulProgrammableSwitchService!);
+  }
+
   public removeSwitchService(accessory: PlatformAccessory) {
     // If switchService still pressent, then remove first
     this.switchService = this.accessory.getService(this.platform.Service.Switch);
@@ -528,7 +567,7 @@ export class Bot {
         this.OnCached = this.On;
         this.accessory.context.On = this.OnCached;
       } else {
-        if (this.deviceStatus.body.power === 'on') {
+        /*if (this.deviceStatus.body.power === 'on') {
           this.On = true;
           this.OnCached = this.On;
           this.accessory.context.On = this.OnCached;
@@ -536,6 +575,11 @@ export class Bot {
           this.On = false;
           this.OnCached = this.On;
           this.accessory.context.On = this.OnCached;
+        }*/
+        this.OnCached = this.On;
+        this.accessory.context.On = this.OnCached;
+        if (this.On === undefined) {
+          this.On = false;
         }
       }
       this.debugLog(`Bot: ${this.accessory.displayName} On: ${this.On}`);
@@ -952,6 +996,23 @@ export class Bot {
         }
       }
       this.debugLog(`Bot: ${this.accessory.displayName} Fan On: ${this.On}`);
+    } else if (this.device.bot?.deviceType === 'stateful') {
+      if (this.On === undefined) {
+        this.debugLog(`Bot: ${this.accessory.displayName} On: ${this.On}`);
+      } else {
+        if (this.On) {
+          this.statefulProgrammableSwitchService?.updateCharacteristic(this.platform.Characteristic.ProgrammableSwitchEvent,
+            this.platform.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
+          this.statefulProgrammableSwitchService?.updateCharacteristic(this.platform.Characteristic.ProgrammableSwitchOutputState, 1);
+          this.debugLog(`Bot: ${this.accessory.displayName} updateCharacteristic ProgrammableSwitchEvent: SINGLE, ProgrammableSwitchOutputState: 1`);
+        } else {
+          this.statefulProgrammableSwitchService?.updateCharacteristic(this.platform.Characteristic.ProgrammableSwitchEvent,
+            this.platform.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
+          this.statefulProgrammableSwitchService?.updateCharacteristic(this.platform.Characteristic.ProgrammableSwitchOutputState, 0);
+          this.debugLog(`Bot: ${this.accessory.displayName} updateCharacteristic ProgrammableSwitchEvent: SINGLE, ProgrammableSwitchOutputState: 0`);
+        }
+      }
+      this.debugLog(`Bot: ${this.accessory.displayName} StatefulProgrammableSwitch On: ${this.On}`);
     } else if (this.device.bot?.deviceType === 'switch') {
       if (this.On === undefined) {
         this.debugLog(`Bot: ${this.accessory.displayName} On: ${this.On}`);
@@ -1007,6 +1068,9 @@ export class Bot {
       this.faucetService?.updateCharacteristic(this.platform.Characteristic.Active, e);
     } else if (this.device.bot?.deviceType === 'fan') {
       this.fanService?.updateCharacteristic(this.platform.Characteristic.On, e);
+    } else if (this.device.bot?.deviceType === 'stateful') {
+      this.statefulProgrammableSwitchService?.updateCharacteristic(this.platform.Characteristic.ProgrammableSwitchEvent, e);
+      this.statefulProgrammableSwitchService?.updateCharacteristic(this.platform.Characteristic.ProgrammableSwitchOutputState, e);
     } else if (this.device.bot?.deviceType === 'switch') {
       this.switchService?.updateCharacteristic(this.platform.Characteristic.On, e);
     } else {
@@ -1091,6 +1155,13 @@ export class Bot {
     } else if (this.device.bot?.deviceType === 'faucet') {
       this.debugLog(`Bot: ${this.accessory.displayName} Active: ${value}`);
       if (value === this.platform.Characteristic.Active.INACTIVE) {
+        this.On = false;
+      } else {
+        this.On = true;
+      }
+    } else if (this.device.bot?.deviceType === 'stateful') {
+      this.debugLog(`Bot: ${this.accessory.displayName} ProgrammableSwitchOutputState: ${value}`);
+      if (value === 0) {
         this.On = false;
       } else {
         this.On = true;

--- a/src/devices/bots.ts
+++ b/src/devices/bots.ts
@@ -463,32 +463,21 @@ export class Bot {
     accessory.removeService(this.switchService!);
   }
 
-  scan(device: device & devicesConfig) {
-    if (device.scanDuration) {
-      this.scanDuration = this.accessory.context.scanDuration = device.scanDuration;
-      if (device.ble) {
-        this.debugLog(`Bot: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
-      }
-    } else {
-      this.scanDuration = this.accessory.context.scanDuration = 1;
-      if (this.device.ble) {
-        this.debugLog(`Bot: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
-      }
-    }
-  }
-
   config(device: device & devicesConfig) {
     const config: any = device.bot;
-    if (device.bot !== undefined) {
-      if (device.ble !== undefined) {
-        config['ble'] = device.ble;
-      }
-      if (device.logging !== undefined) {
-        config['logging'] = device.logging;
-      }
-      if (device.refreshRate !== undefined) {
-        config['refreshRate'] = device.refreshRate;
-      }
+    if (device.ble !== undefined) {
+      config['ble'] = device.ble;
+    }
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (device.refreshRate !== undefined) {
+      config['refreshRate'] = device.refreshRate;
+    }
+    if (device.scanDuration !== undefined) {
+      config['scanDuration'] = device.scanDuration;
+    }
+    if (config !== undefined) {
       this.warnLog(`Bot: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
@@ -500,6 +489,20 @@ export class Bot {
     } else if (this.platform.config.options!.refreshRate) {
       this.deviceRefreshRate = this.accessory.context.refreshRate = this.platform.config.options!.refreshRate;
       this.debugLog(`Bot: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
+    }
+  }
+
+  scan(device: device & devicesConfig) {
+    if (device.scanDuration) {
+      this.scanDuration = this.accessory.context.scanDuration = device.scanDuration;
+      if (device.ble) {
+        this.debugLog(`Bot: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
+      }
+    } else {
+      this.scanDuration = this.accessory.context.scanDuration = 1;
+      if (this.device.ble) {
+        this.debugLog(`Bot: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
+      }
     }
   }
 

--- a/src/devices/bots.ts
+++ b/src/devices/bots.ts
@@ -478,11 +478,18 @@ export class Bot {
   }
 
   config(device: device & devicesConfig) {
+    const config: any = device.bot;
     if (device.bot !== undefined) {
-      device.bot['ble'] = device.ble;
-      device.bot['logging'] = this.deviceLogging;
-      device.bot['refreshRate'] = this.deviceRefreshRate;
-      this.warnLog(`Bot: ${this.accessory.displayName} Config: ${JSON.stringify(device.bot)}`);
+      if (device.ble !== undefined) {
+        config['ble'] = device.ble;
+      }
+      if (device.logging !== undefined) {
+        config['logging'] = device.logging;
+      }
+      if (device.refreshRate !== undefined) {
+        config['refreshRate'] = device.refreshRate;
+      }
+      this.warnLog(`Bot: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 

--- a/src/devices/bots.ts
+++ b/src/devices/bots.ts
@@ -64,9 +64,9 @@ export class Bot {
     public device: device & devicesConfig,
   ) {
     // default placeholders
-    this.logs();
-    this.scan();
-    this.refreshRate();
+    this.logs(device);
+    this.scan(device);
+    this.refreshRate(device);
     this.PressOrSwitch();
     this.config(device);
     if (this.On === undefined) {
@@ -373,12 +373,6 @@ export class Bot {
       });
   }
 
-  config(device: device & devicesConfig) {
-    if (device.bot !== undefined || device.ble !== undefined) {
-      this.warnLog(`Bot: ${this.accessory.displayName} Config: ${JSON.stringify(device.bot)}, BLE: ${device.ble}`);
-    }
-  }
-
   public removeOutletService(accessory: PlatformAccessory) {
     // If outletService still pressent, then remove first
     this.outletService = this.accessory.getService(this.platform.Service.Outlet);
@@ -469,50 +463,52 @@ export class Bot {
     accessory.removeService(this.switchService!);
   }
 
-  refreshRate() {
-    if (this.device.refreshRate) {
-      this.deviceRefreshRate = this.accessory.context.refreshRate = this.device.refreshRate;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Bot: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
-      }
-    } else if (this.platform.config.options!.refreshRate) {
-      this.deviceRefreshRate = this.accessory.context.refreshRate = this.platform.config.options!.refreshRate;
-      if (this.deviceLogging === 'debug') {
-        this.warnLog(`Bot: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
-      }
-    }
-  }
-
-  scan() {
-    if (this.device.scanDuration) {
-      this.scanDuration = this.accessory.context.scanDuration = this.device.scanDuration;
-      if (this.device.ble && (this.deviceLogging === 'debug' || this.deviceLogging === 'standard')) {
-        this.warnLog(`Bot: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
+  scan(device: device & devicesConfig) {
+    if (device.scanDuration) {
+      this.scanDuration = this.accessory.context.scanDuration = device.scanDuration;
+      if (device.ble) {
+        this.debugLog(`Bot: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
       }
     } else {
       this.scanDuration = this.accessory.context.scanDuration = 1;
-      if (this.device.ble && this.deviceLogging === 'debug') {
-        this.warnLog(`Bot: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
+      if (this.device.ble) {
+        this.debugLog(`Bot: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
       }
     }
   }
 
-  logs() {
+  config(device: device & devicesConfig) {
+    if (device.bot !== undefined) {
+      device.bot['ble'] = device.ble;
+      device.bot['logging'] = this.deviceLogging;
+      device.bot['refreshRate'] = this.deviceRefreshRate;
+      this.warnLog(`Bot: ${this.accessory.displayName} Config: ${JSON.stringify(device.bot)}`);
+    }
+  }
+
+  refreshRate(device: device & devicesConfig) {
+    if (device.refreshRate) {
+      this.deviceRefreshRate = this.accessory.context.refreshRate = device.refreshRate;
+      this.debugLog(`Bot: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
+    } else if (this.platform.config.options!.refreshRate) {
+      this.deviceRefreshRate = this.accessory.context.refreshRate = this.platform.config.options!.refreshRate;
+      this.debugLog(`Bot: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
+    }
+  }
+
+  logs(device: device & devicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Bot: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Bot: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Bot: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Bot: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Bot: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Bot: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Bot: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/devices/bots.ts
+++ b/src/devices/bots.ts
@@ -68,7 +68,7 @@ export class Bot {
     this.scan();
     this.refreshRate();
     this.PressOrSwitch();
-
+    this.config(device);
     if (this.On === undefined) {
       this.On = false;
       this.accessory.context.On = this.On;
@@ -83,10 +83,6 @@ export class Bot {
     }
     this.BatteryLevel = 100;
     this.StatusLowBattery = 0;
-
-    // Bot Config
-    this.debugLog(`Bot: ${this.accessory.displayName} Config: (ble: ${device.ble}, offline: ${device.offline}, mode: ${device.bot?.mode},`
-      + ` deviceType: ${device.bot?.deviceType}, doublePress: ${this.doublePress})`);
 
     // this is subject we use to track when we need to POST changes to the SwitchBot API
     this.doBotUpdate = new Subject();
@@ -377,6 +373,12 @@ export class Bot {
       });
   }
 
+  config(device: device & devicesConfig) {
+    if (device.bot !== undefined || device.ble !== undefined) {
+      this.warnLog(`Bot: ${this.accessory.displayName} Config: ${JSON.stringify(device.bot)}, BLE: ${device.ble}`);
+    }
+  }
+
   public removeOutletService(accessory: PlatformAccessory) {
     // If outletService still pressent, then remove first
     this.outletService = this.accessory.getService(this.platform.Service.Outlet);
@@ -470,12 +472,12 @@ export class Bot {
   refreshRate() {
     if (this.device.refreshRate) {
       this.deviceRefreshRate = this.accessory.context.refreshRate = this.device.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
+      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
         this.warnLog(`Bot: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
       }
     } else if (this.platform.config.options!.refreshRate) {
       this.deviceRefreshRate = this.accessory.context.refreshRate = this.platform.config.options!.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
+      if (this.deviceLogging === 'debug') {
         this.warnLog(`Bot: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
       }
     }
@@ -484,12 +486,12 @@ export class Bot {
   scan() {
     if (this.device.scanDuration) {
       this.scanDuration = this.accessory.context.scanDuration = this.device.scanDuration;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
+      if (this.device.ble && (this.deviceLogging === 'debug' || this.deviceLogging === 'standard')) {
         this.warnLog(`Bot: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
       }
     } else {
       this.scanDuration = this.accessory.context.scanDuration = 1;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
+      if (this.device.ble && this.deviceLogging === 'debug') {
         this.warnLog(`Bot: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
       }
     }

--- a/src/devices/colorbulb.ts
+++ b/src/devices/colorbulb.ts
@@ -216,16 +216,19 @@ export class ColorBulb {
 
   config(device: device & devicesConfig) {
     const config: any = device.colorbulb;
-    if (device.colorbulb !== undefined) {
-      if (device.ble !== undefined) {
-        config['ble'] = device.ble;
-      }
-      if (device.logging !== undefined) {
-        config['logging'] = device.logging;
-      }
-      if (device.refreshRate !== undefined) {
-        config['refreshRate'] = device.refreshRate;
-      }
+    if (device.ble !== undefined) {
+      config['ble'] = device.ble;
+    }
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (device.refreshRate !== undefined) {
+      config['refreshRate'] = device.refreshRate;
+    }
+    if (device.scanDuration !== undefined) {
+      config['scanDuration'] = device.scanDuration;
+    }
+    if (config !== undefined) {
       this.warnLog(`Color Bulb: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }

--- a/src/devices/colorbulb.ts
+++ b/src/devices/colorbulb.ts
@@ -61,6 +61,7 @@ export class ColorBulb {
     this.logs();
     this.refreshRate();
     this.adaptiveLighting();
+    this.config(device);
     if (this.On === undefined) {
       this.On = false;
     } else {
@@ -72,11 +73,6 @@ export class ColorBulb {
     this.ColorTemperature = 140;
     this.minKelvin = 2000;
     this.maxKelvin = 9000;
-
-    // ColorBulb Config
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} Config: (ble: ${device.ble}, set_minStep: ${device.colorbulb?.set_minStep},`
-      + ` adaptiveLighting: ${device.colorbulb?.adaptiveLightingShift})`);
-
     // this is subject we use to track when we need to POST changes to the SwitchBot API
     this.doColorBulbUpdate = new Subject();
     this.colorBulbUpdateInProgress = false;
@@ -216,6 +212,12 @@ export class ColorBulb {
         }
         this.colorBulbUpdateInProgress = false;
       });
+  }
+
+  config(device: device & devicesConfig) {
+    if (device.colorbulb !== undefined) {
+      this.debugLog(`Color Bulb: ${this.accessory.displayName} Config: ${JSON.stringify(device.colorbulb)}`);
+    }
   }
 
   refreshRate() {

--- a/src/devices/colorbulb.ts
+++ b/src/devices/colorbulb.ts
@@ -215,11 +215,18 @@ export class ColorBulb {
   }
 
   config(device: device & devicesConfig) {
-    if (device.bot !== undefined) {
-      device.bot['ble'] = device.ble;
-      device.bot['logging'] = this.deviceLogging;
-      device.bot['refreshRate'] = this.deviceRefreshRate;
-      this.warnLog(`Color Bulb: ${this.accessory.displayName} Config: ${JSON.stringify(device.colorbulb)}`);
+    const config: any = device.colorbulb;
+    if (device.colorbulb !== undefined) {
+      if (device.ble !== undefined) {
+        config['ble'] = device.ble;
+      }
+      if (device.logging !== undefined) {
+        config['logging'] = device.logging;
+      }
+      if (device.refreshRate !== undefined) {
+        config['refreshRate'] = device.refreshRate;
+      }
+      this.warnLog(`Color Bulb: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 

--- a/src/devices/colorbulb.ts
+++ b/src/devices/colorbulb.ts
@@ -58,9 +58,9 @@ export class ColorBulb {
     public device: device & devicesConfig,
   ) {
     // default placeholders
-    this.logs();
-    this.refreshRate();
-    this.adaptiveLighting();
+    this.logs(device);
+    this.refreshRate(device);
+    this.adaptiveLighting(device);
     this.config(device);
     if (this.On === undefined) {
       this.On = false;
@@ -215,47 +215,43 @@ export class ColorBulb {
   }
 
   config(device: device & devicesConfig) {
-    if (device.colorbulb !== undefined) {
-      this.debugLog(`Color Bulb: ${this.accessory.displayName} Config: ${JSON.stringify(device.colorbulb)}`);
+    if (device.bot !== undefined) {
+      device.bot['ble'] = device.ble;
+      device.bot['logging'] = this.deviceLogging;
+      device.bot['refreshRate'] = this.deviceRefreshRate;
+      this.warnLog(`Color Bulb: ${this.accessory.displayName} Config: ${JSON.stringify(device.colorbulb)}`);
     }
   }
 
-  refreshRate() {
-    if (this.device.refreshRate) {
-      this.deviceRefreshRate = this.accessory.context.refreshRate = this.device.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Color Bulb: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
-      }
+  refreshRate(device: device & devicesConfig) {
+    if (device.refreshRate) {
+      this.deviceRefreshRate = this.accessory.context.refreshRate = device.refreshRate;
+      this.debugLog(`Color Bulb: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
     } else if (this.platform.config.options!.refreshRate) {
       this.deviceRefreshRate = this.accessory.context.refreshRate = this.platform.config.options!.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Color Bulb: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
-      }
+      this.debugLog(`Color Bulb: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
     }
   }
 
-  logs() {
+  logs(device: device & devicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Color Bulb: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Color Bulb: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Color Bulb: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Color Bulb: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Color Bulb: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Color Bulb: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Color Bulb: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 
-  adaptiveLighting() {
-    if (this.device.colorbulb?.adaptiveLightingShift) {
-      this.adaptiveLightingShift = this.device.colorbulb.adaptiveLightingShift;
+  adaptiveLighting(device: device & devicesConfig) {
+    if (device.colorbulb?.adaptiveLightingShift) {
+      this.adaptiveLightingShift = device.colorbulb.adaptiveLightingShift;
       this.debugLog(`Color Bulb: ${this.accessory.displayName} adaptiveLightingShift: ${this.adaptiveLightingShift}`);
     } else {
       this.adaptiveLightingShift = 0;

--- a/src/devices/contact.ts
+++ b/src/devices/contact.ts
@@ -56,9 +56,9 @@ export class Contact {
     public device: device & devicesConfig,
   ) {
     // default placeholders
-    this.logs();
-    this.scan();
-    this.refreshRate();
+    this.logs(device);
+    this.scan(device);
+    this.refreshRate(device);
     this.config(device);
     this.ContactSensorState = this.platform.Characteristic.ContactSensorState.CONTACT_DETECTED;
 
@@ -156,55 +156,61 @@ export class Contact {
   }
 
   config(device: device & devicesConfig) {
-    if (device.contact !== undefined) {
-      this.warnLog(`Contact Sensor: ${this.accessory.displayName} Config: ${JSON.stringify(device.contact)}`);
+    const config: any = device.contact;
+    if (device.ble !== undefined) {
+      config['ble'] = device.ble;
+    }
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (device.refreshRate !== undefined) {
+      config['refreshRate'] = device.refreshRate;
+    }
+    if (device.scanDuration !== undefined) {
+      config['scanDuration'] = device.scanDuration;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Contact Sensor: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  refreshRate() {
-    if (this.device.refreshRate) {
-      this.deviceRefreshRate = this.accessory.context.refreshRate = this.device.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Contact Sensor: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
-      }
+  refreshRate(device: device & devicesConfig) {
+    if (device.refreshRate) {
+      this.deviceRefreshRate = this.accessory.context.refreshRate = device.refreshRate;
+      this.debugLog(`Contact Sensor: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
     } else if (this.platform.config.options!.refreshRate) {
       this.deviceRefreshRate = this.accessory.context.refreshRate = this.platform.config.options!.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Contact Sensor: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
-      }
+      this.debugLog(`Contact Sensor: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
     }
   }
 
-  scan() {
-    if (this.device.scanDuration) {
-      this.scanDuration = this.accessory.context.scanDuration = this.device.scanDuration;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Contact Sensor: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
+  scan(device: device & devicesConfig) {
+    if (device.scanDuration) {
+      this.scanDuration = this.accessory.context.scanDuration = device.scanDuration;
+      if (device.ble) {
+        this.debugLog(`Contact Sensor: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
       }
     } else {
       this.scanDuration = this.accessory.context.scanDuration = 1;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Contact Sensor: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
+      if (this.device.ble) {
+        this.debugLog(`Contact Sensor: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
       }
     }
   }
 
-  logs() {
+  logs(device: device & devicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Contact Sensor: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Contact Sensor: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Contact Sensor: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Contact Sensor: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Contact Sensor: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Contact Sensor: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Contact Sensor: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/devices/contact.ts
+++ b/src/devices/contact.ts
@@ -59,12 +59,8 @@ export class Contact {
     this.logs();
     this.scan();
     this.refreshRate();
+    this.config(device);
     this.ContactSensorState = this.platform.Characteristic.ContactSensorState.CONTACT_DETECTED;
-
-    // Contact Config
-    this.debugLog(`Contact Sensor: ${this.accessory.displayName} Config: (ble: ${device.ble}, offline: ${device.offline},`
-      + ` hide_lightsensor: ${device.contact?.hide_lightsensor}, hide_motionsensor: ${device.contact?.hide_motionsensor},`
-      + ` set_minLux: ${this.device.contact?.set_minLux}, set_maxLux: ${this.device.contact?.set_maxLux})`);
 
     // this is subject we use to track when we need to POST changes to the SwitchBot API
     this.doContactUpdate = new Subject();
@@ -157,6 +153,12 @@ export class Contact {
       .subscribe(() => {
         this.refreshStatus();
       });
+  }
+
+  config(device: device & devicesConfig) {
+    if (device.contact !== undefined) {
+      this.warnLog(`Contact Sensor: ${this.accessory.displayName} Config: ${JSON.stringify(device.contact)}`);
+    }
   }
 
   refreshRate() {

--- a/src/devices/curtains.ts
+++ b/src/devices/curtains.ts
@@ -151,7 +151,7 @@ export class Curtain {
       this.debugLog(`Curtain: ${accessory.displayName} Removing Battery Service`);
       this.batteryService = this.accessory.getService(this.platform.Service.Battery);
       accessory.removeService(this.batteryService!);
-    } else if (!this.batteryService) {
+    } else if (device.ble && !this.batteryService) {
       this.debugLog(`Curtain: ${accessory.displayName} Add Battery Service`);
       (this.batteryService =
         this.accessory.getService(this.platform.Service.Battery) ||
@@ -340,7 +340,7 @@ export class Curtain {
         // If Curtain calibration distance is short, there will be an error between the current percentage and the target percentage.
         this.TargetPosition = this.CurrentPosition;
         this.PositionState = this.platform.Characteristic.PositionState.STOPPED;
-        this.infoLog(`Curtain: ${this.accessory.displayName} Stopped`);
+        this.debugLog(`Curtain: ${this.accessory.displayName} Stopped`);
       }
     }
     this.debugLog(`Curtain: ${this.accessory.displayName} CurrentPosition: ${this.CurrentPosition},`
@@ -440,7 +440,7 @@ export class Curtain {
           /*If Curtain calibration distance is short, there will be an error between the current percentage and the target percentage.*/
           this.TargetPosition = this.CurrentPosition;
           this.PositionState = this.platform.Characteristic.PositionState.STOPPED;
-          this.infoLog(`Curtain: ${this.accessory.displayName} Stopped`);
+          this.debugLog(`Curtain: ${this.accessory.displayName} Stopped`);
         }
       }
       this.debugLog(`Curtain: ${this.accessory.displayName} CurrentPosition: ${this.CurrentPosition},`
@@ -473,7 +473,6 @@ export class Curtain {
 
   private async BLERefreshStatus() {
     this.debugLog(`Curtain: ${this.accessory.displayName} BLE refreshStatus`);
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
     const switchbot = await this.platform.connectBLE();
     // Convert to BLE Address
     this.device.bleMac = ((this.device.deviceId!.match(/.{1,2}/g))!.join(':')).toLowerCase();

--- a/src/devices/curtains.ts
+++ b/src/devices/curtains.ts
@@ -31,6 +31,7 @@ export class Curtain {
   battery: serviceData['battery'];
   position: serviceData['position'];
   lightLevel: serviceData['lightLevel'];
+  spaceBetweenLevels!: number;
 
   // Target
   setNewTarget!: boolean;
@@ -44,7 +45,6 @@ export class Curtain {
   scanDuration!: number;
   deviceLogging!: string;
   deviceRefreshRate!: number;
-  spaceBetweenLevels!: number;
 
   // Updates
   curtainUpdateInProgress!: boolean;

--- a/src/devices/curtains.ts
+++ b/src/devices/curtains.ts
@@ -211,16 +211,19 @@ export class Curtain {
 
   config(device: device & devicesConfig) {
     const config: any = device.curtain;
-    if (device.curtain !== undefined) {
-      if (device.ble !== undefined) {
-        config['ble'] = device.ble;
-      }
-      if (device.logging !== undefined) {
-        config['logging'] = device.logging;
-      }
-      if (device.refreshRate !== undefined) {
-        config['refreshRate'] = device.refreshRate;
-      }
+    if (device.ble !== undefined) {
+      config['ble'] = device.ble;
+    }
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (device.refreshRate !== undefined) {
+      config['refreshRate'] = device.refreshRate;
+    }
+    if (device.scanDuration !== undefined) {
+      config['scanDuration'] = device.scanDuration;
+    }
+    if (config !== undefined) {
       this.warnLog(`Curtain: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }

--- a/src/devices/curtains.ts
+++ b/src/devices/curtains.ts
@@ -64,6 +64,7 @@ export class Curtain {
     this.scan();
     this.setMinMax();
     this.refreshRate();
+    this.config(device);
     this.CurrentPosition = 0;
     this.TargetPosition = 0;
     this.PositionState = this.platform.Characteristic.PositionState.STOPPED;
@@ -212,6 +213,12 @@ export class Curtain {
         }
         this.curtainUpdateInProgress = false;
       });
+  }
+
+  config(device: device & devicesConfig) {
+    if (device.curtain !== undefined || device.ble !== undefined) {
+      this.warnLog(`Curtain: ${this.accessory.displayName} Config: ${JSON.stringify(device.curtain)}, BLE: ${device.ble}`);
+    }
   }
 
   refreshRate() {

--- a/src/devices/curtains.ts
+++ b/src/devices/curtains.ts
@@ -271,30 +271,6 @@ export class Curtain {
     }
   }
 
-  public async connectBLE() {
-    let switchbot: any;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const Switchbot = require('node-switchbot');
-      switchbot = new Switchbot();
-      // Convert to BLE Address
-      this.device.bleMac = ((this.device.deviceId!.match(/.{1,2}/g))!.join(':')).toLowerCase();
-      this.debugLog(`Curtain: ${this.accessory.displayName} BLE Address: ${this.device.bleMac}`);
-    } catch (e: any) {
-      switchbot = false;
-      this.errorLog(`Curtain: ${this.accessory.displayName} 'node-switchbot' found: ${switchbot}`);
-      if (this.deviceLogging === 'debug') {
-        this.errorLog(`Curtain: ${this.accessory.displayName} 'node-switchbot' found: ${switchbot},`
-          + ` Error Message: ${JSON.stringify(e.message)}`);
-      }
-      if (this.platform.debugMode) {
-        this.errorLog(`Curtain: ${this.accessory.displayName} 'node-switchbot' found: ${switchbot},`
-          + ` Error: ${JSON.stringify(e)}`);
-      }
-    }
-    return switchbot;
-  }
-
   private minStep(): number {
     if (this.device.curtain?.set_minStep) {
       this.set_minStep = this.device.curtain?.set_minStep;
@@ -492,7 +468,10 @@ export class Curtain {
   private async BLERefreshStatus() {
     this.debugLog(`Curtain: ${this.accessory.displayName} BLE refreshStatus`);
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const switchbot = await this.connectBLE();
+    const switchbot = await this.platform.connectBLE();
+    // Convert to BLE Address
+    this.device.bleMac = ((this.device.deviceId!.match(/.{1,2}/g))!.join(':')).toLowerCase();
+    this.debugLog(`Curtain: ${this.accessory.displayName} BLE Address: ${this.device.bleMac}`);
     // Start to monitor advertisement packets
     if (switchbot !== false) {
       switchbot.startScan({
@@ -605,7 +584,10 @@ export class Curtain {
   private async BLEpushChanges() {
     if (this.TargetPosition !== this.CurrentPosition) {
       this.debugLog(`Curtain: ${this.accessory.displayName} BLE pushChanges`);
-      const switchbot = await this.connectBLE();
+      const switchbot = await this.platform.connectBLE();
+      // Convert to BLE Address
+      this.device.bleMac = ((this.device.deviceId!.match(/.{1,2}/g))!.join(':')).toLowerCase();
+      this.debugLog(`Curtain: ${this.accessory.displayName} BLE Address: ${this.device.bleMac}`);
       if (switchbot !== false) {
         switchbot.discover({ model: 'c', quick: true, id: this.device.bleMac }).then((device_list) => {
           this.infoLog(`${this.accessory.displayName} Target Position: ${this.TargetPosition}`);

--- a/src/devices/humidifiers.ts
+++ b/src/devices/humidifiers.ts
@@ -3,7 +3,7 @@ import { interval, Subject } from 'rxjs';
 import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { DeviceURL, device, devicesConfig, serviceData, ad, deviceStatusResponse, payload } from '../settings';
+import { DeviceURL, device, devicesConfig, serviceData, ad, deviceStatusResponse, payload, deviceStatus } from '../settings';
 
 /**
  * Platform Accessory
@@ -25,6 +25,12 @@ export class Humidifier {
   WaterLevel!: CharacteristicValue;
 
   // OpenAPI
+  auto: deviceStatus['auto'];
+  power: deviceStatus['power'];
+  humidity: deviceStatus['humidity'];
+  lackWater: deviceStatus['lackWater'];
+  temperature: deviceStatus['temperature'];
+  nebulizationEfficiency: deviceStatus['nebulizationEfficiency'];
   deviceStatus!: deviceStatusResponse;
 
   // BLE Others
@@ -276,15 +282,15 @@ export class Humidifier {
     if (this.platform.config.credentials?.openToken) {
       this.debugLog(`Humidifier: ${this.accessory.displayName} OpenAPI parseStatus`);
       // Current Relative Humidity
-      this.CurrentRelativeHumidity = this.deviceStatus.body.humidity!;
+      this.CurrentRelativeHumidity = this.humidity!;
       this.debugLog(`Humidifier: ${this.accessory.displayName} CurrentRelativeHumidity: ${this.CurrentRelativeHumidity}`);
       // Current Temperature
       if (!this.device.humidifier?.hide_temperature) {
-        this.CurrentTemperature = Number(this.deviceStatus.body.temperature);
+        this.CurrentTemperature = this.temperature!;
         this.debugLog(`Humidifier: ${this.accessory.displayName} CurrentTemperature: ${this.CurrentTemperature}`);
       }
       // Target Humidifier Dehumidifier State
-      switch (this.deviceStatus.body.auto) {
+      switch (this.auto) {
         case true:
           this.TargetHumidifierDehumidifierState = this.platform.Characteristic.TargetHumidifierDehumidifierState.HUMIDIFIER_OR_DEHUMIDIFIER;
           this.CurrentHumidifierDehumidifierState = this.platform.Characteristic.CurrentHumidifierDehumidifierState.HUMIDIFYING;
@@ -292,10 +298,10 @@ export class Humidifier {
           break;
         default:
           this.TargetHumidifierDehumidifierState = this.platform.Characteristic.TargetHumidifierDehumidifierState.HUMIDIFIER;
-          if (this.deviceStatus.body.nebulizationEfficiency! > 100) {
+          if (this.nebulizationEfficiency! > 100) {
             this.RelativeHumidityHumidifierThreshold = 100;
           } else {
-            this.RelativeHumidityHumidifierThreshold = this.deviceStatus.body.nebulizationEfficiency!;
+            this.RelativeHumidityHumidifierThreshold = this.nebulizationEfficiency!;
           }
           if (this.CurrentRelativeHumidity > this.RelativeHumidityHumidifierThreshold) {
             this.CurrentHumidifierDehumidifierState = this.platform.Characteristic.CurrentHumidifierDehumidifierState.IDLE;
@@ -310,7 +316,7 @@ export class Humidifier {
         + ` RelativeHumidityHumidifierThreshold: ${this.RelativeHumidityHumidifierThreshold}`);
       this.debugLog(`Humidifier: ${this.accessory.displayName} CurrentHumidifierDehumidifierState: ${this.CurrentHumidifierDehumidifierState}`);
       // Active
-      switch (this.deviceStatus.body.power) {
+      switch (this.power) {
         case 'on':
           this.Active = this.platform.Characteristic.Active.ACTIVE;
           break;
@@ -319,7 +325,7 @@ export class Humidifier {
       }
       this.debugLog(`Humidifier: ${this.accessory.displayName} Active: ${this.Active}`);
       // Water Level
-      if (this.deviceStatus.body.lackWater) {
+      if (this.lackWater) {
         this.WaterLevel = 0;
       } else {
         this.WaterLevel = 100;
@@ -339,34 +345,12 @@ export class Humidifier {
     }
   }
 
-  public async connectBLE() {
-    let switchbot: any;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const Switchbot = require('node-switchbot');
-      switchbot = new Switchbot();
-      // Convert to BLE Address
-      this.device.bleMac = ((this.device.deviceId!.match(/.{1,2}/g))!.join(':')).toLowerCase();
-      this.debugLog(`Humidifier: ${this.accessory.displayName} BLE Address: ${this.device.bleMac}`);
-    } catch (e: any) {
-      switchbot = false;
-      this.errorLog(`Humidifier: ${this.accessory.displayName} 'node-switchbot' found: ${switchbot}`);
-      if (this.deviceLogging === 'debug') {
-        this.errorLog(`Humidifier: ${this.accessory.displayName} 'node-switchbot' found: ${switchbot},`
-          + ` Error Message: ${JSON.stringify(e.message)}`);
-      }
-      if (this.platform.debugMode) {
-        this.errorLog(`Humidifier: ${this.accessory.displayName} 'node-switchbot' found: ${switchbot},`
-          + ` Error: ${JSON.stringify(e)}`);
-      }
-    }
-    return switchbot;
-  }
-
   private async BLERefreshStatus() {
     this.debugLog(`Humidifier: ${this.accessory.displayName} BLE refreshStatus`);
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const switchbot = await this.connectBLE();
+    const switchbot = await this.platform.connectBLE();
+    // Convert to BLE Address
+    this.device.bleMac = ((this.device.deviceId!.match(/.{1,2}/g))!.join(':')).toLowerCase();
+    this.debugLog(`Curtain: ${this.accessory.displayName} BLE Address: ${this.device.bleMac}`);
     // Start to monitor advertisement packets
     if (switchbot !== false) {
       switchbot.startScan({
@@ -438,10 +422,16 @@ export class Humidifier {
         this.deviceStatus = (await this.platform.axios.get(`${DeviceURL}/${this.device.deviceId}/status`)).data;
         if (this.deviceStatus.message === 'success') {
           this.debugLog(`Humidifier: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(this.deviceStatus)}`);
+          this.auto = this.deviceStatus.body.auto;
+          this.power = this.deviceStatus.body.power;
+          this.lackWater = this.deviceStatus.body.lackWater;
+          this.humidity = this.deviceStatus.body.humidity;
+          this.temperature = this.deviceStatus.body.temperature;
+          this.nebulizationEfficiency = this.deviceStatus.body.nebulizationEfficiency;
           this.parseStatus();
           this.updateHomeKitCharacteristics();
         } else {
-          this.debugLog(this.deviceStatus);
+          this.errorLog(`Humidifier: ${this.accessory.displayName} message: ${JSON.stringify(this.deviceStatus.message)}`);
         }
       } catch (e: any) {
         this.errorLog(`Humidifier: ${this.accessory.displayName} failed refreshStatus with OpenAPI Connection`);
@@ -477,7 +467,10 @@ export class Humidifier {
 
   private async BLEpushChanges() {
     this.debugLog(`Humidifier: ${this.accessory.displayName} BLE pushChanges`);
-    const switchbot = await this.connectBLE();
+    const switchbot = await this.platform.connectBLE();
+    // Convert to BLE Address
+    this.device.bleMac = ((this.device.deviceId!.match(/.{1,2}/g))!.join(':')).toLowerCase();
+    this.debugLog(`Curtain: ${this.accessory.displayName} BLE Address: ${this.device.bleMac}`);
     if (switchbot !== false) {
       switchbot.discover({ model: 'e', quick: true, id: this.device.bleMac }).then((device_list) => {
         this.infoLog(`${this.accessory.displayName} Target Position: ${this.Active}`);

--- a/src/devices/humidifiers.ts
+++ b/src/devices/humidifiers.ts
@@ -59,6 +59,7 @@ export class Humidifier {
     this.logs();
     this.scan();
     this.refreshRate();
+    this.config(device);
     this.CurrentRelativeHumidity = 0;
     this.TargetHumidifierDehumidifierState = this.platform.Characteristic.TargetHumidifierDehumidifierState.HUMIDIFIER;
     this.CurrentHumidifierDehumidifierState = this.platform.Characteristic.CurrentHumidifierDehumidifierState.INACTIVE;
@@ -195,6 +196,12 @@ export class Humidifier {
         }
         this.humidifierUpdateInProgress = false;
       });
+  }
+
+  config(device: device & devicesConfig) {
+    if (device.humidifier !== undefined || device.ble !== undefined) {
+      this.warnLog(`Humidifier: ${this.accessory.displayName} Config: ${JSON.stringify(device.humidifier)}, BLE: ${device.ble}`);
+    }
   }
 
   refreshRate() {

--- a/src/devices/humidifiers.ts
+++ b/src/devices/humidifiers.ts
@@ -154,7 +154,7 @@ export class Humidifier {
           minStep: 0.1,
         })
         .onGet(() => {
-          return Number.isNaN(this.CurrentTemperature);
+          return this.CurrentTemperature;
         });
     } else {
       this.debugLog(`Humidifier: ${accessory.displayName} Temperature Sensor Service Not Added`);
@@ -199,8 +199,18 @@ export class Humidifier {
   }
 
   config(device: device & devicesConfig) {
-    if (device.humidifier !== undefined || device.ble !== undefined) {
-      this.warnLog(`Humidifier: ${this.accessory.displayName} Config: ${JSON.stringify(device.humidifier)}, BLE: ${device.ble}`);
+    const config: any = device.humidifier;
+    if (device.humidifier !== undefined) {
+      if (device.ble !== undefined) {
+        config['ble'] = device.ble;
+      }
+      if (device.logging !== undefined) {
+        config['logging'] = device.logging;
+      }
+      if (device.refreshRate !== undefined) {
+        config['refreshRate'] = device.refreshRate;
+      }
+      this.warnLog(`Humidifier: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 

--- a/src/devices/humidifiers.ts
+++ b/src/devices/humidifiers.ts
@@ -200,16 +200,19 @@ export class Humidifier {
 
   config(device: device & devicesConfig) {
     const config: any = device.humidifier;
-    if (device.humidifier !== undefined) {
-      if (device.ble !== undefined) {
-        config['ble'] = device.ble;
-      }
-      if (device.logging !== undefined) {
-        config['logging'] = device.logging;
-      }
-      if (device.refreshRate !== undefined) {
-        config['refreshRate'] = device.refreshRate;
-      }
+    if (device.ble !== undefined) {
+      config['ble'] = device.ble;
+    }
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (device.refreshRate !== undefined) {
+      config['refreshRate'] = device.refreshRate;
+    }
+    if (device.scanDuration !== undefined) {
+      config['scanDuration'] = device.scanDuration;
+    }
+    if (config !== undefined) {
       this.warnLog(`Humidifier: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }

--- a/src/devices/meters.ts
+++ b/src/devices/meters.ts
@@ -58,6 +58,7 @@ export class Meter {
     this.logs();
     this.scan();
     this.refreshRate();
+    this.config(device);
     if (this.CurrentRelativeHumidity === undefined) {
       this.CurrentRelativeHumidity = 0;
     } else {
@@ -171,6 +172,12 @@ export class Meter {
       .subscribe(() => {
         this.refreshStatus();
       });
+  }
+
+  config(device: device & devicesConfig) {
+    if (device.meter !== undefined || device.ble !== undefined) {
+      this.warnLog(`Meter: ${this.accessory.displayName} Config: ${JSON.stringify(device.meter)}, BLE: ${device.ble}`);
+    }
   }
 
   refreshRate() {

--- a/src/devices/meters.ts
+++ b/src/devices/meters.ts
@@ -55,9 +55,9 @@ export class Meter {
     public device: device & devicesConfig,
   ) {
     // default placeholders
-    this.logs();
-    this.scan();
-    this.refreshRate();
+    this.logs(device);
+    this.scan(device);
+    this.refreshRate(device);
     this.config(device);
     if (this.CurrentRelativeHumidity === undefined) {
       this.CurrentRelativeHumidity = 0;
@@ -175,55 +175,61 @@ export class Meter {
   }
 
   config(device: device & devicesConfig) {
-    if (device.meter !== undefined || device.ble !== undefined) {
-      this.warnLog(`Meter: ${this.accessory.displayName} Config: ${JSON.stringify(device.meter)}, BLE: ${device.ble}`);
+    const config: any = device.meter;
+    if (device.ble !== undefined) {
+      config['ble'] = device.ble;
+    }
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (device.refreshRate !== undefined) {
+      config['refreshRate'] = device.refreshRate;
+    }
+    if (device.scanDuration !== undefined) {
+      config['scanDuration'] = device.scanDuration;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Meter: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  refreshRate() {
-    if (this.device.refreshRate) {
-      this.deviceRefreshRate = this.accessory.context.refreshRate = this.device.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Meter: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
-      }
+  refreshRate(device: device & devicesConfig) {
+    if (device.refreshRate) {
+      this.deviceRefreshRate = this.accessory.context.refreshRate = device.refreshRate;
+      this.debugLog(`Meter: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
     } else if (this.platform.config.options!.refreshRate) {
       this.deviceRefreshRate = this.accessory.context.refreshRate = this.platform.config.options!.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Meter: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
-      }
+      this.debugLog(`Meter: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
     }
   }
 
-  scan() {
-    if (this.device.scanDuration) {
-      this.scanDuration = this.accessory.context.scanDuration = this.device.scanDuration;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Meter: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
+  scan(device: device & devicesConfig) {
+    if (device.scanDuration) {
+      this.scanDuration = this.accessory.context.scanDuration = device.scanDuration;
+      if (device.ble) {
+        this.debugLog(`Meter: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
       }
     } else {
       this.scanDuration = this.accessory.context.scanDuration = 1;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Meter: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
+      if (this.device.ble) {
+        this.debugLog(`Meter: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
       }
     }
   }
 
-  logs() {
+  logs(device: device & devicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Meter: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Meter: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Meter: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Meter: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Meter: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Meter: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Meter: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 
@@ -415,16 +421,16 @@ export class Meter {
     }
     if (this.device.ble) {
       if (this.BatteryLevel === undefined) {
-        this.debugLog(`Bot: ${this.accessory.displayName} BatteryLevel: ${this.BatteryLevel}`);
+        this.debugLog(`Meter: ${this.accessory.displayName} BatteryLevel: ${this.BatteryLevel}`);
       } else {
         this.batteryService?.updateCharacteristic(this.platform.Characteristic.BatteryLevel, this.BatteryLevel);
-        this.debugLog(`Bot: ${this.accessory.displayName} updateCharacteristic BatteryLevel: ${this.BatteryLevel}`);
+        this.debugLog(`Meter: ${this.accessory.displayName} updateCharacteristic BatteryLevel: ${this.BatteryLevel}`);
       }
       if (this.StatusLowBattery === undefined) {
-        this.debugLog(`Bot: ${this.accessory.displayName} StatusLowBattery: ${this.StatusLowBattery}`);
+        this.debugLog(`Meter: ${this.accessory.displayName} StatusLowBattery: ${this.StatusLowBattery}`);
       } else {
         this.batteryService?.updateCharacteristic(this.platform.Characteristic.StatusLowBattery, this.StatusLowBattery);
-        this.debugLog(`Bot: ${this.accessory.displayName} updateCharacteristic StatusLowBattery: ${this.StatusLowBattery}`);
+        this.debugLog(`Meter: ${this.accessory.displayName} updateCharacteristic StatusLowBattery: ${this.StatusLowBattery}`);
       }
     }
   }

--- a/src/devices/meters.ts
+++ b/src/devices/meters.ts
@@ -33,6 +33,7 @@ export class Meter {
   // BLE Others
   connected?: boolean;
   switchbot!: switchbot;
+  SwitchToOpenAPI?: boolean;
   serviceData!: serviceData;
   temperature!: temperature['c'];
   battery!: serviceData['battery'];
@@ -232,10 +233,10 @@ export class Meter {
    * Parse the device status from the SwitchBot api
    */
   async parseStatus() {
-    if (this.device.ble) {
-      await this.BLEparseStatus();
-    } else {
+    if (this.SwitchToOpenAPI || !this.device.ble) {
       await this.openAPIparseStatus();
+    } else {
+      await this.BLEparseStatus();
     }
   }
 
@@ -266,6 +267,9 @@ export class Meter {
   }
 
   private async openAPIparseStatus() {
+    if (this.device.ble) {
+      this.SwitchToOpenAPI = false;
+    }
     if (this.platform.config.credentials?.openToken) {
       this.debugLog(`Meter: ${this.accessory.displayName} OpenAPI parseStatus`);
       if (this.deviceStatus.body) {
@@ -385,6 +389,7 @@ export class Meter {
         }
         if (this.platform.config.credentials?.openToken) {
           this.warnLog(`Meter: ${this.accessory.displayName} Using OpenAPI Connection`);
+          this.SwitchToOpenAPI = true;
           this.openAPIRefreshStatus();
         }
         this.apiError(e);
@@ -398,6 +403,7 @@ export class Meter {
     this.errorLog(`Meter: ${this.accessory.displayName} wasn't able to establish BLE Connection, node-switchbot: ${switchbot}`);
     if (this.platform.config.credentials?.openToken) {
       this.warnLog(`Meter: ${this.accessory.displayName} Using OpenAPI Connection`);
+      this.SwitchToOpenAPI = true;
       await this.openAPIRefreshStatus();
     }
   }

--- a/src/devices/motion.ts
+++ b/src/devices/motion.ts
@@ -115,7 +115,7 @@ export class Motion {
       this.debugLog(`Motion Sensor: ${accessory.displayName} Removing Battery Service`);
       this.batteryService = this.accessory.getService(this.platform.Service.Battery);
       accessory.removeService(this.batteryService!);
-    } else if (!this.batteryService) {
+    } else if (device.ble && !this.batteryService) {
       this.debugLog(`Motion Sensor: ${accessory.displayName} Add Battery Service`);
       (this.batteryService =
         this.accessory.getService(this.platform.Service.Battery) ||
@@ -285,34 +285,12 @@ export class Motion {
     }
   }
 
-  public async connectBLE() {
-    let switchbot: any;
-    try {
-      // eslint-disable-next-line @typescript-eslint/no-var-requires
-      const Switchbot = require('node-switchbot');
-      switchbot = new Switchbot();
-      // Convert to BLE Address
-      this.device.bleMac = ((this.device.deviceId!.match(/.{1,2}/g))!.join(':')).toLowerCase();
-      this.debugLog(`Motion Sensor: ${this.accessory.displayName} BLE Address: ${this.device.bleMac}`);
-    } catch (e: any) {
-      switchbot = false;
-      this.errorLog(`Motion Sensor: ${this.accessory.displayName} 'node-switchbot' found: ${switchbot}`);
-      if (this.deviceLogging === 'debug') {
-        this.errorLog(`Motion Sensor: ${this.accessory.displayName} 'node-switchbot' found: ${switchbot},`
-          + ` Error Message: ${JSON.stringify(e.message)}`);
-      }
-      if (this.platform.debugMode) {
-        this.errorLog(`Motion Sensor: ${this.accessory.displayName} 'node-switchbot' found: ${switchbot},`
-          + ` Error: ${JSON.stringify(e)}`);
-      }
-    }
-    return switchbot;
-  }
-
   private async BLERefreshStatus() {
     this.debugLog(`Motion Sensor: ${this.accessory.displayName} BLE RefreshStatus`);
-    // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const switchbot = await this.connectBLE();
+    const switchbot = await this.platform.connectBLE();
+    // Convert to BLE Address
+    this.device.bleMac = ((this.device.deviceId!.match(/.{1,2}/g))!.join(':')).toLowerCase();
+    this.debugLog(`Curtain: ${this.accessory.displayName} BLE Address: ${this.device.bleMac}`);
     // Start to monitor advertisement packets
     if (switchbot !== false) {
       switchbot.startScan({

--- a/src/devices/motion.ts
+++ b/src/devices/motion.ts
@@ -2,7 +2,7 @@ import { interval, Subject } from 'rxjs';
 import { skipWhile } from 'rxjs/operators';
 import { SwitchBotPlatform } from '../platform';
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { DeviceURL, device, devicesConfig, serviceData, switchbot, deviceStatusResponse } from '../settings';
+import { DeviceURL, device, devicesConfig, serviceData, switchbot, deviceStatusResponse, deviceStatus } from '../settings';
 
 /**
  * Platform Accessory
@@ -23,6 +23,8 @@ export class Motion {
 
   // OpenAPI Others
   deviceStatus!: deviceStatusResponse;
+  moveDetected: deviceStatus['moveDetected'];
+  brightness: deviceStatus['brightness'];
 
   // BLE Others
   connected?: boolean;
@@ -43,8 +45,6 @@ export class Motion {
   // Updates
   motionUbpdateInProgress!: boolean;
   doMotionUpdate!: Subject<void>;
-  moveDetected: boolean | undefined;
-  brightness: string | number | undefined;
 
   constructor(
     private readonly platform: SwitchBotPlatform,

--- a/src/devices/motion.ts
+++ b/src/devices/motion.ts
@@ -55,6 +55,7 @@ export class Motion {
     this.logs();
     this.scan();
     this.refreshRate();
+    this.config(device);
     this.MotionDetected = false;
 
     // Motion Config
@@ -136,6 +137,12 @@ export class Motion {
       .subscribe(() => {
         this.refreshStatus();
       });
+  }
+
+  config(device: device & devicesConfig) {
+    if (device.motion !== undefined) {
+      this.warnLog(`Motion Sensor: ${this.accessory.displayName} Config: ${JSON.stringify(device.motion)}`);
+    }
   }
 
   refreshRate() {

--- a/src/devices/motion.ts
+++ b/src/devices/motion.ts
@@ -52,9 +52,9 @@ export class Motion {
     public device: device & devicesConfig,
   ) {
     // default placeholders
-    this.logs();
-    this.scan();
-    this.refreshRate();
+    this.logs(device);
+    this.scan(device);
+    this.refreshRate(device);
     this.config(device);
     this.MotionDetected = false;
 
@@ -140,55 +140,61 @@ export class Motion {
   }
 
   config(device: device & devicesConfig) {
-    if (device.motion !== undefined) {
-      this.warnLog(`Motion Sensor: ${this.accessory.displayName} Config: ${JSON.stringify(device.motion)}`);
+    const config: any = device.motion;
+    if (device.ble !== undefined) {
+      config['ble'] = device.ble;
+    }
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (device.refreshRate !== undefined) {
+      config['refreshRate'] = device.refreshRate;
+    }
+    if (device.scanDuration !== undefined) {
+      config['scanDuration'] = device.scanDuration;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Motion Sensor: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  refreshRate() {
-    if (this.device.refreshRate) {
-      this.deviceRefreshRate = this.accessory.context.refreshRate = this.device.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Motion Sensor: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
-      }
+  refreshRate(device: device & devicesConfig) {
+    if (device.refreshRate) {
+      this.deviceRefreshRate = this.accessory.context.refreshRate = device.refreshRate;
+      this.debugLog(`Motion Sensor: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
     } else if (this.platform.config.options!.refreshRate) {
       this.deviceRefreshRate = this.accessory.context.refreshRate = this.platform.config.options!.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Motion Sensor: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
-      }
+      this.debugLog(`Motion Sensor: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
     }
   }
 
-  scan() {
-    if (this.device.scanDuration) {
-      this.scanDuration = this.accessory.context.scanDuration = this.device.scanDuration;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Motion Sensor: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
+  scan(device: device & devicesConfig) {
+    if (device.scanDuration) {
+      this.scanDuration = this.accessory.context.scanDuration = device.scanDuration;
+      if (device.ble) {
+        this.debugLog(`Motion Sensor: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
       }
     } else {
       this.scanDuration = this.accessory.context.scanDuration = 1;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Motion Sensor: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
+      if (this.device.ble) {
+        this.debugLog(`Motion Sensor: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
       }
     }
   }
 
-  logs() {
+  logs(device: device & devicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Motion Sensor: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Motion Sensor: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Motion Sensor: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Motion Sensor: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Motion Sensor: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Motion Sensor: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Motion Sensor: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/devices/plugs.ts
+++ b/src/devices/plugs.ts
@@ -33,9 +33,9 @@ export class Plug {
     public device: device & devicesConfig,
   ) {
     // default placeholders
-    this.logs();
-    this.scan();
-    this.refreshRate();
+    this.logs(device);
+    this.scan(device);
+    this.refreshRate(device);
     this.config(device);
     if (this.On === undefined) {
       this.On = false;
@@ -119,55 +119,61 @@ export class Plug {
   }
 
   config(device: device & devicesConfig) {
-    if (device.plug !== undefined) {
-      this.warnLog(`Plug: ${this.accessory.displayName} Config: ${JSON.stringify(device.plug)}`);
+    const config: any = device.plug;
+    if (device.ble !== undefined) {
+      config['ble'] = device.ble;
+    }
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (device.refreshRate !== undefined) {
+      config['refreshRate'] = device.refreshRate;
+    }
+    if (device.scanDuration !== undefined) {
+      config['scanDuration'] = device.scanDuration;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Plug: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  refreshRate() {
-    if (this.device.refreshRate) {
-      this.deviceRefreshRate = this.accessory.context.refreshRate = this.device.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Plug: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
-      }
+  refreshRate(device: device & devicesConfig) {
+    if (device.refreshRate) {
+      this.deviceRefreshRate = this.accessory.context.refreshRate = device.refreshRate;
+      this.debugLog(`Plug: ${this.accessory.displayName} Using Device Config refreshRate: ${this.deviceRefreshRate}`);
     } else if (this.platform.config.options!.refreshRate) {
       this.deviceRefreshRate = this.accessory.context.refreshRate = this.platform.config.options!.refreshRate;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Plug: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
-      }
+      this.debugLog(`Plug: ${this.accessory.displayName} Using Platform Config refreshRate: ${this.deviceRefreshRate}`);
     }
   }
 
-  scan() {
-    if (this.device.scanDuration) {
-      this.scanDuration = this.accessory.context.scanDuration = this.device.scanDuration;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Plug: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
+  scan(device: device & devicesConfig) {
+    if (device.scanDuration) {
+      this.scanDuration = this.accessory.context.scanDuration = device.scanDuration;
+      if (device.ble) {
+        this.debugLog(`Plug: ${this.accessory.displayName} Using Device Config scanDuration: ${this.scanDuration}`);
       }
     } else {
       this.scanDuration = this.accessory.context.scanDuration = 1;
-      if (this.platform.debugMode || (this.deviceLogging === 'debug')) {
-        this.warnLog(`Plug: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
+      if (this.device.ble) {
+        this.debugLog(`Plug: ${this.accessory.displayName} Using Default scanDuration: ${this.scanDuration}`);
       }
     }
   }
 
-  logs() {
+  logs(device: device & devicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Plug: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Plug: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Plug: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Plug: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Plug: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Plug: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Plug: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/devices/plugs.ts
+++ b/src/devices/plugs.ts
@@ -36,6 +36,7 @@ export class Plug {
     this.logs();
     this.scan();
     this.refreshRate();
+    this.config(device);
     if (this.On === undefined) {
       this.On = false;
     } else {
@@ -115,6 +116,12 @@ export class Plug {
         }
         this.plugUpdateInProgress = false;
       });
+  }
+
+  config(device: device & devicesConfig) {
+    if (device.plug !== undefined) {
+      this.warnLog(`Plug: ${this.accessory.displayName} Config: ${JSON.stringify(device.plug)}`);
+    }
   }
 
   refreshRate() {

--- a/src/devices/plugs.ts
+++ b/src/devices/plugs.ts
@@ -4,7 +4,7 @@ import { interval, Subject } from 'rxjs';
 import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { DeviceURL, device, devicesConfig, deviceStatusResponse, payload } from '../settings';
+import { DeviceURL, device, devicesConfig, deviceStatusResponse, payload, deviceStatus } from '../settings';
 
 export class Plug {
   // Services
@@ -15,6 +15,7 @@ export class Plug {
   OnCached!: CharacteristicValue;
 
   // OpenAPI Others
+  power: deviceStatus['power'];
   deviceStatus!: deviceStatusResponse;
 
   // Config
@@ -164,7 +165,7 @@ export class Plug {
   }
 
   parseStatus() {
-    switch (this.deviceStatus.body.power) {
+    switch (this.power) {
       case 'on':
         this.On = true;
         break;
@@ -178,6 +179,7 @@ export class Plug {
     try {
       this.deviceStatus = (await this.platform.axios.get(`${DeviceURL}/${this.device.deviceId}/status`)).data;
       this.debugLog(`Plug: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(this.deviceStatus)}`);
+      this.power = this.deviceStatus.body.power;
       this.parseStatus();
       this.updateHomeKitCharacteristics();
     } catch (e: any) {

--- a/src/irdevices/airconditioners.ts
+++ b/src/irdevices/airconditioners.ts
@@ -50,6 +50,7 @@ export class AirConditioner {
   ) {
     // default placeholders
     this.logs();
+    this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
     } else {
@@ -164,6 +165,12 @@ export class AirConditioner {
         return this.RotationSpeedGet();
       })
       .onSet(this.RotationSpeedSet.bind(this));
+  }
+
+  config(device: irdevice & irDevicesConfig) {
+    if (device.irair !== undefined) {
+      this.warnLog(`Air Conditioner: ${this.accessory.displayName} Config: ${JSON.stringify(device.irair)}`);
+    }
   }
 
   logs() {

--- a/src/irdevices/airconditioners.ts
+++ b/src/irdevices/airconditioners.ts
@@ -49,7 +49,7 @@ export class AirConditioner {
     public device: irdevice & irDevicesConfig,
   ) {
     // default placeholders
-    this.logs();
+    this.logs(device);
     this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
@@ -168,27 +168,28 @@ export class AirConditioner {
   }
 
   config(device: irdevice & irDevicesConfig) {
-    if (device.irair !== undefined) {
-      this.warnLog(`Air Conditioner: ${this.accessory.displayName} Config: ${JSON.stringify(device.irair)}`);
+    const config: any = device.irair;
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Air Conditioner: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  logs() {
+  logs(device: irdevice & irDevicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Air Conditioner: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Air Conditioner: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Air Conditioner: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Air Conditioner: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Air Conditioner: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Air Conditioner: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Air Conditioner: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/irdevices/airpurifiers.ts
+++ b/src/irdevices/airpurifiers.ts
@@ -45,6 +45,7 @@ export class AirPurifier {
   ) {
     // default placeholders
     this.logs();
+    this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
     } else {
@@ -85,6 +86,12 @@ export class AirPurifier {
     });
 
     this.service.getCharacteristic(this.platform.Characteristic.TargetAirPurifierState).onSet(this.TargetAirPurifierStateSet.bind(this));
+  }
+
+  config(device: irdevice & irDevicesConfig) {
+    if (device.irpur !== undefined) {
+      this.warnLog(`Air Purifier: ${this.accessory.displayName} Config: ${JSON.stringify(device.irpur)}`);
+    }
   }
 
   logs() {

--- a/src/irdevices/airpurifiers.ts
+++ b/src/irdevices/airpurifiers.ts
@@ -44,7 +44,7 @@ export class AirPurifier {
     public device: irdevice & irDevicesConfig,
   ) {
     // default placeholders
-    this.logs();
+    this.logs(device);
     this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
@@ -89,36 +89,37 @@ export class AirPurifier {
   }
 
   config(device: irdevice & irDevicesConfig) {
-    if (device.irpur !== undefined) {
-      this.warnLog(`Air Purifier: ${this.accessory.displayName} Config: ${JSON.stringify(device.irpur)}`);
+    const config: any = device.irpur;
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Air Purifier: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  logs() {
+  logs(device: irdevice & irDevicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Air Purifier: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Air Purifier: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Air Purifier: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Air Purifier: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Air Purifier: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Air Purifier: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Air Purifier: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 
   private ActiveSet(value: CharacteristicValue) {
     this.debugLog(`Air Purifier: ${this.accessory.displayName} Set Active: ${value}`);
     if (value === this.platform.Characteristic.Active.INACTIVE) {
-      this.pushAirConditionerOffChanges();
+      this.pushAirPurifierOffChanges();
     } else {
-      this.pushAirConditionerOnChanges();
+      this.pushAirPurifierOnChanges();
     }
     this.Active = value;
     this.ActiveCached = this.Active;
@@ -184,7 +185,7 @@ export class AirPurifier {
    * AirPurifier:        "command"       "middleSpeed"    "default"	        =        fan speed to medium
    * AirPurifier:        "command"       "highSpeed"      "default"	        =        fan speed to high
    */
-  async pushAirConditionerOnChanges() {
+  async pushAirPurifierOnChanges() {
     if (this.Active !== 1) {
       const payload = {
         commandType: 'command',
@@ -195,7 +196,7 @@ export class AirPurifier {
     }
   }
 
-  async pushAirConditionerOffChanges() {
+  async pushAirPurifierOffChanges() {
     if (this.Active !== 0) {
       const payload = {
         commandType: 'command',

--- a/src/irdevices/cameras.ts
+++ b/src/irdevices/cameras.ts
@@ -26,6 +26,7 @@ export class Camera {
   ) {
     // default placeholders
     this.logs();
+    this.config(device);
     if (this.On === undefined) {
       this.On = false;
     } else {
@@ -55,6 +56,12 @@ export class Camera {
 
     // handle on / off events using the On characteristic
     this.service.getCharacteristic(this.platform.Characteristic.On).onSet(this.OnSet.bind(this));
+  }
+
+  config(device: irdevice & irDevicesConfig) {
+    if (device.ircam !== undefined && (this.deviceLogging === 'debug' || this.deviceLogging === 'standard')) {
+      this.warnLog(`Camera: ${this.accessory.displayName} Config: ${JSON.stringify(device.ircam)}`);
+    }
   }
 
   logs() {

--- a/src/irdevices/cameras.ts
+++ b/src/irdevices/cameras.ts
@@ -25,7 +25,7 @@ export class Camera {
     public device: irdevice & irDevicesConfig,
   ) {
     // default placeholders
-    this.logs();
+    this.logs(device);
     this.config(device);
     if (this.On === undefined) {
       this.On = false;
@@ -59,27 +59,28 @@ export class Camera {
   }
 
   config(device: irdevice & irDevicesConfig) {
-    if (device.ircam !== undefined && (this.deviceLogging === 'debug' || this.deviceLogging === 'standard')) {
-      this.warnLog(`Camera: ${this.accessory.displayName} Config: ${JSON.stringify(device.ircam)}`);
+    const config: any = device.ircam;
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Camera: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  logs() {
+  logs(device: irdevice & irDevicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Camera: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Camera: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Camera: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Camera: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Camera: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Camera: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Camera: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/irdevices/fans.ts
+++ b/src/irdevices/fans.ts
@@ -35,7 +35,7 @@ export class Fan {
     public device: irdevice & irDevicesConfig,
   ) {
     // default placeholders
-    this.logs();
+    this.logs(device);
     this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
@@ -118,27 +118,28 @@ export class Fan {
   }
 
   config(device: irdevice & irDevicesConfig) {
-    if (device.irfan !== undefined && (this.deviceLogging === 'debug' || this.deviceLogging === 'standard')) {
-      this.warnLog(`Fan: ${this.accessory.displayName} Config: ${JSON.stringify(device.irfan)}`);
+    const config: any = device.irfan;
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Fan: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  logs() {
+  logs(device: irdevice & irDevicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Fan: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Fan: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Fan: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Fan: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Fan: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Fan: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Fan: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/irdevices/fans.ts
+++ b/src/irdevices/fans.ts
@@ -36,6 +36,7 @@ export class Fan {
   ) {
     // default placeholders
     this.logs();
+    this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
     } else {
@@ -113,6 +114,12 @@ export class Fan {
       // eslint-disable-next-line max-len
       this.debugLog(`Fan: ${this.accessory.displayName} Swing Mode Characteristic was not removed or not added. To Remove Chracteristic, Clear Cache on this Accessory.`);
 
+    }
+  }
+
+  config(device: irdevice & irDevicesConfig) {
+    if (device.irfan !== undefined && (this.deviceLogging === 'debug' || this.deviceLogging === 'standard')) {
+      this.warnLog(`Fan: ${this.accessory.displayName} Config: ${JSON.stringify(device.irfan)}`);
     }
   }
 

--- a/src/irdevices/lights.ts
+++ b/src/irdevices/lights.ts
@@ -26,6 +26,7 @@ export class Light {
   ) {
     // default placeholders
     this.logs();
+    this.config(device);
     if (this.On === undefined) {
       this.On = false;
     } else {
@@ -70,6 +71,12 @@ export class Light {
         this.service.updateCharacteristic(this.platform.Characteristic.Active, this.Brightness);
         callback(null);
       });*/
+  }
+
+  config(device: irdevice & irDevicesConfig) {
+    if (device.irlight !== undefined) {
+      this.warnLog(`Light: ${this.accessory.displayName} Config: ${JSON.stringify(device.irlight)}`);
+    }
   }
 
   logs() {

--- a/src/irdevices/lights.ts
+++ b/src/irdevices/lights.ts
@@ -25,7 +25,7 @@ export class Light {
     public device: irdevice & irDevicesConfig,
   ) {
     // default placeholders
-    this.logs();
+    this.logs(device);
     this.config(device);
     if (this.On === undefined) {
       this.On = false;
@@ -74,27 +74,28 @@ export class Light {
   }
 
   config(device: irdevice & irDevicesConfig) {
-    if (device.irlight !== undefined) {
-      this.warnLog(`Light: ${this.accessory.displayName} Config: ${JSON.stringify(device.irlight)}`);
+    const config: any = device.irlight;
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Light: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  logs() {
+  logs(device: irdevice & irDevicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Light: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Light: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Light: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Light: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Light: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Light: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Light: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/irdevices/others.ts
+++ b/src/irdevices/others.ts
@@ -28,6 +28,7 @@ export class Others {
     // default placeholders
     this.logs();
     this.deviceType();
+    this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
     } else {
@@ -73,6 +74,12 @@ export class Others {
       }
     } else {
       this.errorLog(`Other: ${this.accessory.displayName} No Device Type Set, deviceType: ${this.device.other?.deviceType}`);
+    }
+  }
+
+  config(device: irdevice & irDevicesConfig) {
+    if (device.other !== undefined) {
+      this.warnLog(`Other: ${this.accessory.displayName} Config: ${JSON.stringify(device.other)}`);
     }
   }
 

--- a/src/irdevices/others.ts
+++ b/src/irdevices/others.ts
@@ -26,8 +26,8 @@ export class Others {
     public device: irdevice & irDevicesConfig,
   ) {
     // default placeholders
-    this.logs();
-    this.deviceType();
+    this.logs(device);
+    this.deviceType(device);
     this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
@@ -66,9 +66,9 @@ export class Others {
     }
   }
 
-  deviceType() {
-    if (this.device?.other?.deviceType) {
-      this.otherDeviceType = this.accessory.context.deviceType = this.device?.other?.deviceType;
+  deviceType(device: irdevice & irDevicesConfig) {
+    if (device.other?.deviceType) {
+      this.otherDeviceType = this.accessory.context.deviceType = device.other.deviceType;
       if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
         this.warnLog(`Other: ${this.accessory.displayName} Using Device Type: ${this.otherDeviceType}`);
       }
@@ -78,27 +78,28 @@ export class Others {
   }
 
   config(device: irdevice & irDevicesConfig) {
-    if (device.other !== undefined) {
-      this.warnLog(`Other: ${this.accessory.displayName} Config: ${JSON.stringify(device.other)}`);
+    const config: any = device.other;
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Other: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  logs() {
+  logs(device: irdevice & irDevicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Other: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Other: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Other: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Other: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Other: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Other: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Other: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/irdevices/tvs.ts
+++ b/src/irdevices/tvs.ts
@@ -30,7 +30,7 @@ export class TV {
     public device: irdevice & irDevicesConfig,
   ) {
     // default placeholders
-    this.logs();
+    this.logs(device);
     this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
@@ -130,27 +130,28 @@ export class TV {
   }
 
   config(device: irdevice & irDevicesConfig) {
-    if (device.irtv !== undefined) {
-      this.warnLog(`${this.device.remoteType}: ${this.accessory.displayName} Config: ${JSON.stringify(device.irtv)}`);
+    const config: any = device.irtv;
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (config !== undefined) {
+      this.warnLog(`${this.device.remoteType}: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  logs() {
+  logs(device: irdevice & irDevicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`${this.device.remoteType}: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`${this.device.remoteType}: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`${this.device.remoteType}: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/irdevices/tvs.ts
+++ b/src/irdevices/tvs.ts
@@ -31,6 +31,7 @@ export class TV {
   ) {
     // default placeholders
     this.logs();
+    this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
     } else {
@@ -126,6 +127,12 @@ export class TV {
     this.speakerService
       .getCharacteristic(this.platform.Characteristic.VolumeSelector)
       .onSet(this.VolumeSelectorSet.bind(this));
+  }
+
+  config(device: irdevice & irDevicesConfig) {
+    if (device.irtv !== undefined) {
+      this.warnLog(`${this.device.remoteType}: ${this.accessory.displayName} Config: ${JSON.stringify(device.irtv)}`);
+    }
   }
 
   logs() {

--- a/src/irdevices/vacuumcleaners.ts
+++ b/src/irdevices/vacuumcleaners.ts
@@ -25,7 +25,7 @@ export class VacuumCleaner {
     public device: irdevice & irDevicesConfig,
   ) {
     // default placeholders
-    this.logs();
+    this.logs(device);
     this.config(device);
     if (this.On === undefined) {
       this.On = false;
@@ -59,27 +59,28 @@ export class VacuumCleaner {
   }
 
   config(device: irdevice & irDevicesConfig) {
-    if (device.irvc !== undefined) {
-      this.warnLog(`Vacuum Cleaner: ${this.accessory.displayName} Config: ${JSON.stringify(device.irvc)}`);
+    const config: any = device.irvc;
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Vacuum Cleaner: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  logs() {
+  logs(device: irdevice & irDevicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Vacuum Cleaner: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Vacuum Cleaner: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Vacuum Cleaner: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Vacuum Cleaner: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Vacuum Cleaner: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Vacuum Cleaner: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Vacuum Cleaner: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/irdevices/vacuumcleaners.ts
+++ b/src/irdevices/vacuumcleaners.ts
@@ -26,6 +26,7 @@ export class VacuumCleaner {
   ) {
     // default placeholders
     this.logs();
+    this.config(device);
     if (this.On === undefined) {
       this.On = false;
     } else {
@@ -55,6 +56,12 @@ export class VacuumCleaner {
 
     // handle on / off events using the On characteristic
     this.service.getCharacteristic(this.platform.Characteristic.On).onSet(this.OnSet.bind(this));
+  }
+
+  config(device: irdevice & irDevicesConfig) {
+    if (device.irvc !== undefined) {
+      this.warnLog(`Vacuum Cleaner: ${this.accessory.displayName} Config: ${JSON.stringify(device.irvc)}`);
+    }
   }
 
   logs() {

--- a/src/irdevices/waterheaters.ts
+++ b/src/irdevices/waterheaters.ts
@@ -25,7 +25,7 @@ export class WaterHeater {
     public device: irdevice & irDevicesConfig,
   ) {
     // default placeholders
-    this.logs();
+    this.logs(device);
     this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
@@ -68,27 +68,28 @@ export class WaterHeater {
   }
 
   config(device: irdevice & irDevicesConfig) {
-    if (device.irwh !== undefined) {
-      this.warnLog(`Water Heater: ${this.accessory.displayName} Config: ${JSON.stringify(device.irwh)}`);
+    const config: any = device.irwh;
+    if (device.logging !== undefined) {
+      config['logging'] = device.logging;
+    }
+    if (config !== undefined) {
+      this.warnLog(`Water Heater: ${this.accessory.displayName} Config: ${JSON.stringify(config)}`);
     }
   }
 
-  logs() {
+  logs(device: irdevice & irDevicesConfig) {
     if (this.platform.debugMode) {
-      this.deviceLogging = this.accessory.context.logging = 'debug';
-      this.warnLog(`Water Heater: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
-    } else if (this.device.logging) {
-      this.deviceLogging = this.accessory.context.logging = this.device.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Water Heater: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
-      }
+      this.deviceLogging = this.accessory.context.logging = 'debugMode';
+      this.debugLog(`Water Heater: ${this.accessory.displayName} Using Debug Mode Logging: ${this.deviceLogging}`);
+    } else if (device.logging) {
+      this.deviceLogging = this.accessory.context.logging = device.logging;
+      this.debugLog(`Water Heater: ${this.accessory.displayName} Using Device Config Logging: ${this.deviceLogging}`);
     } else if (this.platform.config.options?.logging) {
       this.deviceLogging = this.accessory.context.logging = this.platform.config.options?.logging;
-      if (this.deviceLogging === 'debug' || this.deviceLogging === 'standard') {
-        this.warnLog(`Water Heater: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
-      }
+      this.debugLog(`Water Heater: ${this.accessory.displayName} Using Platform Config Logging: ${this.deviceLogging}`);
     } else {
       this.deviceLogging = this.accessory.context.logging = 'standard';
+      this.debugLog(`Water Heater: ${this.accessory.displayName} Logging Not Set, Using: ${this.deviceLogging}`);
     }
   }
 

--- a/src/irdevices/waterheaters.ts
+++ b/src/irdevices/waterheaters.ts
@@ -26,6 +26,7 @@ export class WaterHeater {
   ) {
     // default placeholders
     this.logs();
+    this.config(device);
     if (this.Active === undefined) {
       this.Active = this.platform.Characteristic.Active.INACTIVE;
     } else {
@@ -64,6 +65,12 @@ export class WaterHeater {
 
     // handle on / off events using the Active characteristic
     this.service.getCharacteristic(this.platform.Characteristic.Active).onSet(this.ActiveSet.bind(this));
+  }
+
+  config(device: irdevice & irDevicesConfig) {
+    if (device.irwh !== undefined) {
+      this.warnLog(`Water Heater: ${this.accessory.displayName} Config: ${JSON.stringify(device.irwh)}`);
+    }
   }
 
   logs() {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -192,8 +192,21 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
     }
   }
 
+  connectBLE() {
+    let Switchbot: new () => any;
+    let switchbot: any;
+    try {
+      Switchbot = require('node-switchbot');
+      switchbot = new Switchbot();
+    } catch (e) {
+      switchbot = false;
+      this.errorLog(`Was 'node-switchbot' found: ${switchbot}`);
+    }
+    return switchbot;
+  }
+
   /**
- * this method discovers the Locations
+ * this method discovers devices
  */
   async discoverDevices() {
     try {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -78,7 +78,7 @@ export type curtain = {
   hide_lightsensor?: boolean;
   set_minLux?: number;
   set_maxLux?: number;
-  refreshRate?: number;
+  updateRate?: number;
   set_max?: number;
   set_min?: number;
   set_minStep?: number;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -50,6 +50,7 @@ export interface devicesConfig extends device {
   contact?: contact;
   motion?: motion;
   colorbulb?: colorbulb;
+  plug?: undefined;
   ble?: string;
   scanDuration?: number;
   hide_device?: boolean;
@@ -107,6 +108,11 @@ export interface irDevicesConfig extends irdevice {
   logging?: string;
   irfan?: irfan;
   irair?: irair;
+  irpur?: undefined;
+  ircam?: undefined;
+  irlight?: undefined;
+  irvc?: undefined;
+  irwh?: undefined;
   irtv?: irtv;
   other?: other;
   hide_device?: boolean;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -50,7 +50,7 @@ export interface devicesConfig extends device {
   contact?: contact;
   motion?: motion;
   colorbulb?: colorbulb;
-  plug?: undefined;
+  plug?: Record<any, any>;
   ble?: string;
   scanDuration?: number;
   hide_device?: boolean;
@@ -108,11 +108,11 @@ export interface irDevicesConfig extends irdevice {
   logging?: string;
   irfan?: irfan;
   irair?: irair;
-  irpur?: undefined;
-  ircam?: undefined;
-  irlight?: undefined;
-  irvc?: undefined;
-  irwh?: undefined;
+  irpur?: Record<any, any>;
+  ircam?: Record<any, any>;
+  irlight?: Record<any, any>;
+  irvc?: Record<any, any>;
+  irwh?: Record<any, any>;
   irtv?: irtv;
   other?: other;
   hide_device?: boolean;

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -84,6 +84,8 @@ export type curtain = {
 
 export type contact = {
   hide_lightsensor?: boolean;
+  set_minLux?: number;
+  set_maxLux?: number;
   hide_motionsensor?: boolean;
 };
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -48,6 +48,7 @@ export interface devicesConfig extends device {
   humidifier?: humidifier;
   curtain?: curtain;
   contact?: contact;
+  motion?: motion;
   colorbulb?: colorbulb;
   ble?: string;
   scanDuration?: number;
@@ -87,6 +88,12 @@ export type contact = {
   set_minLux?: number;
   set_maxLux?: number;
   hide_motionsensor?: boolean;
+};
+
+export type motion = {
+  hide_lightsensor?: boolean;
+  set_minLux?: number;
+  set_maxLux?: number;
 };
 
 export type colorbulb = {


### PR DESCRIPTION
## [Version 1.8.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.8.0) (2022-01-14)

## What's Changed
* Added option to display Bot a Stateful Programmable Switch.
    * This will only Works in 3rd Party Home App, Like [Eve](https://apps.apple.com/us/app/eve-for-homekit/id917695792) or [Home+ 5](https://apps.apple.com/us/app/home-5/id995994352)
* Add option to Hide Motion Sensor's Light Sensor.
* Add option to Set Motion Sensor's Light Sensor `set_minLux` and `set_maxLux`.
* Fixed Bug: Where BLE config would show for devices that don't support BLE.
* Fixed Bug: Contact Sensors's Motion Sensor and Light Sensor showing undefined values.
* Fixed Bug: Motion Sensors's Light Sensor showing undefined values.
* Fixed Bug: Battery Service wouldn't be removed from Curtain, Contact Sensor, or Motion Sensor when switching from BLE to OpenAPI.
* Enhancments: Made some improvemnt on the switch from BLE to OpenAPI when BLE connection fails.
* Enhancments: Made Optional Switchbot Device Settings and Optional IR Device Settings more managable by using Tabs.
* Change: Changed Curtain `refreshRate` to `updateRate`.
    * You will have to update your config for it to pickup the new `updateRate`.
* Housekeeping and updated dependencies.

**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.7.0...v1.8.0