### PR TITLE
Fix minimum and maximum curtain state

### DIFF
--- a/src/devices/curtains.ts
+++ b/src/devices/curtains.ts
@@ -57,7 +57,6 @@ export class Curtain {
     // default placeholders
     this.logs(device);
     this.scan(device);
-    this.setMinMax();
     this.refreshRate(device);
     this.config(device);
     this.CurrentPosition = 0;

--- a/src/devices/curtains.ts
+++ b/src/devices/curtains.ts
@@ -230,12 +230,10 @@ export class Curtain {
       }
     } else {
       this.debugLog(`Curtain: ${this.accessory.displayName} Standby, CurrentPosition: ${this.CurrentPosition}`);
-      if (!this.setNewTarget) {
-        // If Curtain calibration distance is short, there will be an error between the current percentage and the target percentage.
-        this.TargetPosition = this.CurrentPosition;
-        this.PositionState = this.platform.Characteristic.PositionState.STOPPED;
-        this.debugLog(`Curtain: ${this.accessory.displayName} Stopped`);
-      }
+      // If Curtain calibration distance is short, there will be an error between the current percentage and the target percentage.
+      this.TargetPosition = this.CurrentPosition;
+      this.PositionState = this.platform.Characteristic.PositionState.STOPPED;
+      this.debugLog(`Curtain: ${this.accessory.displayName} Stopped`);
     }
     this.debugLog(
       `Curtain: ${this.accessory.displayName} CurrentPosition: ${this.CurrentPosition},` +

--- a/src/devices/curtains.ts
+++ b/src/devices/curtains.ts
@@ -209,8 +209,8 @@ export class Curtain {
   private async BLEparseStatus() {
     this.debugLog(`Curtain: ${this.accessory.displayName} BLE parseStatus`);
     // CurrentPosition
-    this.setMinMax();
     this.CurrentPosition = 100 - Number(this.position);
+    this.setMinMax();
     this.debugLog(`Curtain: ${this.accessory.displayName} CurrentPosition ${this.CurrentPosition}`);
     if (this.setNewTarget) {
       this.infoLog(`Curtain: ${this.accessory.displayName} Checking Status ...`);
@@ -312,8 +312,8 @@ export class Curtain {
     if (this.platform.config.credentials?.openToken) {
       this.debugLog(`Curtain: ${this.accessory.displayName} OpenAPI parseStatus`);
       // CurrentPosition
-      this.setMinMax();
       this.CurrentPosition = 100 - Number(this.slidePosition);
+      this.setMinMax();
       this.debugLog(`Curtain ${this.accessory.displayName} CurrentPosition: ${this.CurrentPosition}`);
       if (this.setNewTarget) {
         this.infoLog(`Curtain: ${this.accessory.displayName} Checking Status ...`);


### PR DESCRIPTION
## :recycle: Current situation

The curtain `set_min` and `set_max` options do not appear to work correctly.

## :bulb: Proposed solution

It looks like the `setMinMax` call needs to occur after the previous line otherwise the `CurrentPosition` value would always be redefined. Fixes https://github.com/OpenWonderLabs/homebridge-switchbot/issues/123.

## :heavy_plus_sign: Additional Information

The `setMinMax` in the constructor is removed as the `CurrentPosition` value is redefined later in the method. The `!this.setNewTarget` conditional was also removed because it would always evaluate to true.