### PR TITLE
Fix final curtain position state

### DIFF
--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -584,6 +584,7 @@ export class Curtain {
     if (this.PositionState === undefined) {
       this.debugLog(`Curtain: ${this.accessory.displayName} PositionState: ${this.PositionState}`);
     } else {
+      this.windowCoveringService.updateCharacteristic(this.platform.Characteristic.PositionState, Number(this.PositionState));
       this.debugLog(`Curtain: ${this.accessory.displayName} updateCharacteristic PositionState: ${this.PositionState}`);
     }
     if (this.TargetPosition === undefined || Number.isNaN(this.TargetPosition)) {


### PR DESCRIPTION
## :recycle: Current situation

The Homebridge UI can get stuck in an opening or closing curtain position. It appears to have been introduced in the `1.0.3-beta.5` npm version.

## :bulb: Proposed solution

Update the position state when other states are updated.