### PR TITLE
Version 1.12.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,302 +2,344 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
+## [Version 1.12.2](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.12.2) (2022-02-02)
+
+## What's Changed
+
+- Fix: Issue where `PositionState` was not being sent back to Home App. Fixes [#123](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/123) Thanks [@dnicolson](https://github.com/dnicolson)!
+
+**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.12.1...v1.12.2
+
 ## [Version 1.12.1](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.12.1) (2022-02-01)
 
 ## What's Changed
-* Housekeeping and updated dependencies.
+
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.12.0...v1.12.1
 
 ## [Version 1.12.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.12.0) (2022-01-29)
 
 ## What's Changed
-* Add option `maxRetry` for bots so you can set the number of retries for sending on or off for Bot.
+
+- Add option `maxRetry` for bots so you can set the number of retries for sending on or off for Bot.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.11.2...v1.12.0
 
 ## [Version 1.11.2](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.11.2) (2022-01-29)
 
 ## What's Changed
-* Fix: Use `updateRate` instead of `refreshRate` when overriding `scanDuration`.
+
+- Fix: Use `updateRate` instead of `refreshRate` when overriding `scanDuration`.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.11.1...v1.11.2
 
 ## [Version 1.11.1](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.11.1) (2022-01-29)
 
 ## What's Changed
-* Fix: `This plugin generated a warning from the characteristic 'Brightness': characteristic value expected valid finite number and received "undefined" (undefined)`.
-* Fix: `This plugin generated a warning from the characteristic 'Color Temperature': characteristic value expected valid finite number and received "undefined" (undefined)`.
-* Fix: `This plugin generated a warning from the characteristic 'Hue': characteristic value expected valid finite number and received "undefined" (undefined)`.
-* Fix: `This plugin generated a warning from the characteristic 'Saturation': characteristic value expected valid finite number and received "undefined" (undefined)`.
+
+- Fix: `This plugin generated a warning from the characteristic 'Brightness': characteristic value expected valid finite number and received "undefined" (undefined)`.
+- Fix: `This plugin generated a warning from the characteristic 'Color Temperature': characteristic value expected valid finite number and received "undefined" (undefined)`.
+- Fix: `This plugin generated a warning from the characteristic 'Hue': characteristic value expected valid finite number and received "undefined" (undefined)`.
+- Fix: `This plugin generated a warning from the characteristic 'Saturation': characteristic value expected valid finite number and received "undefined" (undefined)`.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.11.0...v1.11.1
 
 ## [Version 1.11.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.11.0) (2022-01-29)
 
 ## What's Changed
-* Add Support for SwitchBot Smart Lock
-* Add Support for SwitchBot Strip Light
-* Add Support for SwitchBot Meter Plus (US)
-* Add Support for SwitchBot Meter Plus (JP)
-* Add Support for SwitchBot Plug Mini (US)
-* Add Support for SwitchBot Plug Mini (US)
-* Fixed: Curtain `set_min` and `set_max` options not work correctly with minimum and maximum curtain state. [#123](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/123)
-* Housekeeping and updated dependencies.
+
+- Add Support for SwitchBot Smart Lock
+- Add Support for SwitchBot Strip Light
+- Add Support for SwitchBot Meter Plus (US)
+- Add Support for SwitchBot Meter Plus (JP)
+- Add Support for SwitchBot Plug Mini (US)
+- Add Support for SwitchBot Plug Mini (US)
+- Fixed: Curtain `set_min` and `set_max` options not work correctly with minimum and maximum curtain state. [#123](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/123)
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.10.1...v1.11.0
 
 ## [Version 1.10.1](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.10.1) (2022-01-26)
 
 ## What's Changed
-* Fixed: Option `pushOn` was not push `On` commands.
-* Housekeeping and updated dependencies.
+
+- Fixed: Option `pushOn` was not push `On` commands.
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.10.0...v1.10.1
 
 ## [Version 1.10.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.10.0) (2022-01-21)
 
 ## What's Changed
-* Add option `pushOn`, this will allow the `On` commands to be sent along side `Status` change commands.
-* Housekeeping and updated dependencies.
+
+- Add option `pushOn`, this will allow the `On` commands to be sent along side `Status` change commands.
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.9.0...v1.10.0
 
 ## [Version 1.9.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.9.0) (2022-01-20)
 
 ## What's Changed
-* Add option `allowPush`, this will allow commands to be sent even if device state is already in state that is being pushed.
-* Housekeeping and updated dependencies.
+
+- Add option `allowPush`, this will allow commands to be sent even if device state is already in state that is being pushed.
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.8.2...v1.9.0
 
 ## [Version 1.8.2](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.8.2) (2022-01-15)
 
 ## What's Changed
-* Fixed Bug: Only log config if it is set.
+
+- Fixed Bug: Only log config if it is set.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.8.1...v1.8.2
 
 ## [Version 1.8.1](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.8.1) (2022-01-15)
 
 ## What's Changed
-* Fixed Bug: Cannot set properties of undefined (setting 'logging')
+
+- Fixed Bug: Cannot set properties of undefined (setting 'logging')
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.8.0...v1.8.1
 
 ## [Version 1.8.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.8.0) (2022-01-14)
 
 ## What's Changed
-* Added option to display Bot a Stateful Programmable Switch.
-    * This will only Works in 3rd Party Home App, Like [Eve](https://apps.apple.com/us/app/eve-for-homekit/id917695792) or [Home+ 5](https://apps.apple.com/us/app/home-5/id995994352)
-* Add option to Hide Motion Sensor's Light Sensor.
-* Add option to Set Motion Sensor's Light Sensor `set_minLux` and `set_maxLux`.
-* Fixed Bug: Where BLE config would show for devices that don't support BLE.
-* Fixed Bug: Contact Sensors's Motion Sensor and Light Sensor showing undefined values.
-* Fixed Bug: Motion Sensors's Light Sensor showing undefined values.
-* Fixed Bug: Battery Service wouldn't be removed from Curtain, Contact Sensor, or Motion Sensor when switching from BLE to OpenAPI.
-* Enhancments: Made some improvemnt on the switch from BLE to OpenAPI when BLE connection fails.
-* Enhancments: Made Optional Switchbot Device Settings and Optional IR Device Settings more managable by using Tabs.
-* Change: Changed Curtain `refreshRate` to `updateRate`.
-    * You will have to update your config for it to pickup the new `updateRate`.
-* Housekeeping and updated dependencies.
+
+- Added option to display Bot a Stateful Programmable Switch.
+  - This will only Works in 3rd Party Home App, Like [Eve](https://apps.apple.com/us/app/eve-for-homekit/id917695792) or [Home+ 5](https://apps.apple.com/us/app/home-5/id995994352)
+- Add option to Hide Motion Sensor's Light Sensor.
+- Add option to Set Motion Sensor's Light Sensor `set_minLux` and `set_maxLux`.
+- Fixed Bug: Where BLE config would show for devices that don't support BLE.
+- Fixed Bug: Contact Sensors's Motion Sensor and Light Sensor showing undefined values.
+- Fixed Bug: Motion Sensors's Light Sensor showing undefined values.
+- Fixed Bug: Battery Service wouldn't be removed from Curtain, Contact Sensor, or Motion Sensor when switching from BLE to OpenAPI.
+- Enhancments: Made some improvemnt on the switch from BLE to OpenAPI when BLE connection fails.
+- Enhancments: Made Optional Switchbot Device Settings and Optional IR Device Settings more managable by using Tabs.
+- Change: Changed Curtain `refreshRate` to `updateRate`.
+  - You will have to update your config for it to pickup the new `updateRate`.
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.7.0...v1.8.0
 
 ## [Version 1.7.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.7.0) (2022-01-05)
 
 ## What's Changed
-* Added option to display Bot a Fan.
-* Added option to display Bot a Door. [#179](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/179)
-* Added option to display Bot a Lock. [#179](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/179)
-* Added option to display Bot a Faucet.
-* Added option to display Bot a Window.
-* Added option to display Bot a WindowCovering.
-* Added option to display Bot a Garage Door Opener.  [#179](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/179)
+
+- Added option to display Bot a Fan.
+- Added option to display Bot a Door. [#179](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/179)
+- Added option to display Bot a Lock. [#179](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/179)
+- Added option to display Bot a Faucet.
+- Added option to display Bot a Window.
+- Added option to display Bot a WindowCovering.
+- Added option to display Bot a Garage Door Opener. [#179](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/179)
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.6.3...v1.7.0
 
 ## [Version 1.6.3](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.6.3) (2022-01-03)
 
 ## What's Changed
-* Quick Fix for for issue not tested in `v1.6.2`.
+
+- Quick Fix for for issue not tested in `v1.6.2`.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.6.2...v1.6.3
 
 ## [Version 1.6.2](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.6.2) (2022-01-03)
 
 ## What's Changed
-* Fixed Bug: npm ERR! code 1. [#151](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/151)
-    * Made `node-switchbot` an optionalDependencies
-    * So If `node-switchbot` doesn't get installed successfully then BLE will not work.
-* Housekeeping and updated dependencies.
+
+- Fixed Bug: npm ERR! code 1. [#151](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/151)
+  - Made `node-switchbot` an optionalDependencies
+  - So If `node-switchbot` doesn't get installed successfully then BLE will not work.
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.6.1...v1.6.2
 
 ## [Version 1.6.1](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.6.1) (2022-01-02)
 
 ## What's Changed
-* Fixed an issue where when `Adaptive Lighting Shift` was set to -1, Adaptive Lighting would not be removed.
-* Fixed an issue with motion sensor refreshStatus that would cause plugin to cause Homebridge restart.
-* Fixed Bug: npm ERR! code 1. [#151](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/151)
-    * Made `node-switchbot` an optionalDependencies
-    * So If `node-switchbot` doesn't get installed successfully then BLE will not work.
-* Housekeeping and updated dependencies.
+
+- Fixed an issue where when `Adaptive Lighting Shift` was set to -1, Adaptive Lighting would not be removed.
+- Fixed an issue with motion sensor refreshStatus that would cause plugin to cause Homebridge restart.
+- Fixed Bug: npm ERR! code 1. [#151](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/151)
+  - Made `node-switchbot` an optionalDependencies
+  - So If `node-switchbot` doesn't get installed successfully then BLE will not work.
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.6.0...v1.6.1
 
 ## [Version 1.6.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.6.0) (2021-12-31)
 
 ## What's Changed
-* Added `scanDuration` config option to set how long BLE scans, Scanning Duration is defaulted to 1 second.
-* Now Setting `switch` as the default bot mode for Bots, to change to press, config must be set under `SwitchBot Device Settings` in the Plugin Settings.
-* Fixed Bug: Contact Sensor talks about Curtain Light + Motion Sensor. [#164](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/164)
-* Fixed Bug: Reboot causes No Device Type Set Error. [#172](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/172)
-* Fixed Bug: Bot Status not working Correction with Switch and Press. [#105](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/105), [#130](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/130), [#132](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/132), [#165](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/165), [#174](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/174)
-* Fixed some issues with the New Logging Options release with v1.5.0, now logging when configured.
+
+- Added `scanDuration` config option to set how long BLE scans, Scanning Duration is defaulted to 1 second.
+- Now Setting `switch` as the default bot mode for Bots, to change to press, config must be set under `SwitchBot Device Settings` in the Plugin Settings.
+- Fixed Bug: Contact Sensor talks about Curtain Light + Motion Sensor. [#164](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/164)
+- Fixed Bug: Reboot causes No Device Type Set Error. [#172](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/172)
+- Fixed Bug: Bot Status not working Correction with Switch and Press. [#105](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/105), [#130](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/130), [#132](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/132), [#165](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/165), [#174](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/174)
+- Fixed some issues with the New Logging Options release with v1.5.0, now logging when configured.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.5.0...v1.6.0
 
 ## [Version 1.5.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.5.0) (2021-12-27)
 
 ## What's Changed
+
 ### Major Change To `Logging`:
-* Added the following Logging Options:
-    * `Standard`
-    * `None`
-    * `Debug`
-* Removed Device Logging Option, which was pushed into new logging under debug.
-* Added Device Logging Override for each Device, by using the Device Config.
+
+- Added the following Logging Options:
+  - `Standard`
+  - `None`
+  - `Debug`
+- Removed Device Logging Option, which was pushed into new logging under debug.
+- Added Device Logging Override for each Device, by using the Device Config.
 
 ### Major Changes to `refreshRate`:
-* Added an option to override `refreshRate` for each Device, by using the Device Config.
+
+- Added an option to override `refreshRate` for each Device, by using the Device Config.
 
 ### Other Changes
-* Fixed Bug: Air conditioner temperature not able to change. [#43](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/43)
-* Housekeeping and updated dependencies.
+
+- Fixed Bug: Air conditioner temperature not able to change. [#43](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/43)
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.4.0...v1.5.0
 
 ## [Version 1.4.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.4.0) (2021-12-15)
 
 ## What's Changed
-* Added Status Messages to logs for discoverDevices request.
-* Added Cached Status to IR device, Status will be saved to accessory context and restored on restart.
-* Added Option `Offline as Off` to be able set the device as off, if API reports offline.
-* Removed Meter Unit Config Option as it was confusing and probably never used.
-* Housekeeping and updated dependencies.
+
+- Added Status Messages to logs for discoverDevices request.
+- Added Cached Status to IR device, Status will be saved to accessory context and restored on restart.
+- Added Option `Offline as Off` to be able set the device as off, if API reports offline.
+- Removed Meter Unit Config Option as it was confusing and probably never used.
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.3.0...v1.4.0
 
 ## [Version 1.3.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.3.0) (2021-12-02)
 
 ## What's Changed
-* Added Adpative Lighting to Color Bulb
-* Added Option `Adaptive Lighting Shift` to be able us this value to increase the mired for the Adaptive Lighting update, making the light appear warmer.
-* Fixed Bug: Color Bulb can't change color and is not dimmable. [#97](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/97)
+
+- Added Adpative Lighting to Color Bulb
+- Added Option `Adaptive Lighting Shift` to be able us this value to increase the mired for the Adaptive Lighting update, making the light appear warmer.
+- Fixed Bug: Color Bulb can't change color and is not dimmable. [#97](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/97)
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.2.5...v1.3.0
 
 ## [Version 1.2.5](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.5) (2021-11-25)
 
 ## What's Changed
-* Fixed Bug: Where `set_minLux` & `set_maxLux` config settings not effecting OpenAPI Lux.
+
+- Fixed Bug: Where `set_minLux` & `set_maxLux` config settings not effecting OpenAPI Lux.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.2.4...v1.2.5
 
 ## [Version 1.2.4](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.4) (2021-11-24)
 
 ## What's Changed
-* Fixed Bug: Cannot read properties of undefined (reading 'updateCharacteristic').
+
+- Fixed Bug: Cannot read properties of undefined (reading 'updateCharacteristic').
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.2.3...v1.2.4
 
 ## [Version 1.2.3](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.3) (2021-11-24)
 
 ## What's Changed
-* When BLE Connection isn't established, allow for OpenAPI to kick in if `openToken` is supplied.
+
+- When BLE Connection isn't established, allow for OpenAPI to kick in if `openToken` is supplied.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.2.2...v1.2.3
 
 ## [Version 1.2.2](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.2) (2021-11-24)
 
 ## What's Changed
-* Allow the `configDeviceName` to override `deviceName`.
-* Added Logging when BLE Connection wasn't established.
+
+- Allow the `configDeviceName` to override `deviceName`.
+- Added Logging when BLE Connection wasn't established.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.2.1...v1.2.2
 
 ## [Version 1.2.1](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.1) (2021-11-24)
 
 ## What's Changed
-* Fixed Bug: Curtains alternate between open/close state. [#85](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/85)
-* Fixed Bug: Meter not working with BLE. [#110](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/110)
-* Housekeeping and updated dependencies.
+
+- Fixed Bug: Curtains alternate between open/close state. [#85](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/85)
+- Fixed Bug: Meter not working with BLE. [#110](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/110)
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.2.0...v1.2.1
 
 ## [Version 1.2.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.2.0) (2021-11-19)
 
 ## What's Changed
-* Added option to be able to do Bluetooth Low Energy (BLE) Only Connection.
-    * Must supply `Device ID` & `Device Name` to the Device Config
-    * Must Check `Enable Bluetooth Low Energy (BLE) Connection`
-* Fixed Bug: Air conditioner temperature not able to change. [#43](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/43)
-* Add option to set Min Lux and Max Lux for Curtain's Light Sensor.
-* Add `updateHomeKitCharacteristics` to IR Devices to contain all `updateCharacteristics` in one spot.
-* Add `Saturation` and `Hue` to Colorbulb.
-* Housekeeping and updated dependencies.
+
+- Added option to be able to do Bluetooth Low Energy (BLE) Only Connection.
+  - Must supply `Device ID` & `Device Name` to the Device Config
+  - Must Check `Enable Bluetooth Low Energy (BLE) Connection`
+- Fixed Bug: Air conditioner temperature not able to change. [#43](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/43)
+- Add option to set Min Lux and Max Lux for Curtain's Light Sensor.
+- Add `updateHomeKitCharacteristics` to IR Devices to contain all `updateCharacteristics` in one spot.
+- Add `Saturation` and `Hue` to Colorbulb.
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.1.0...v1.2.0
 
 ## [Version 1.1.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.1.0) (2021-11-16)
 
 ## What's Changed
-* Fixed Bug: Curtains alternate between open/close state. [#85](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/85)
-* Fixed Bug: IR Fan won't be hidden in Home app. [#90](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/90)
-* Fixed Bug: `hide_temperature` config option causing `Cannot read property 'updateCharacteristic' of undefined` for  Humidifiers. [#89](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/89)
-* Add option to Hide Curtain's Light Sensor. [#91](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/91)
-* Add option to Hide Contact Sensor's Motion Sensor or Light Sensor.
+
+- Fixed Bug: Curtains alternate between open/close state. [#85](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/85)
+- Fixed Bug: IR Fan won't be hidden in Home app. [#90](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/90)
+- Fixed Bug: `hide_temperature` config option causing `Cannot read property 'updateCharacteristic' of undefined` for Humidifiers. [#89](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/89)
+- Add option to Hide Curtain's Light Sensor. [#91](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/91)
+- Add option to Hide Contact Sensor's Motion Sensor or Light Sensor.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.0.2...v1.1.0
 
 ## [Version 1.0.2](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.0.2) (2021-11-15)
 
 ## What's Changed
-* Fixed Bug: `failed to discover devices. cannot read property 'touppercase' of undefined`. [#84](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/84)
-* Housekeeping and updated dependencies.
+
+- Fixed Bug: `failed to discover devices. cannot read property 'touppercase' of undefined`. [#84](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/84)
+- Housekeeping and updated dependencies.
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.0.1...v1.0.2
 
 ## [Version 1.0.1](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.0.1) (2021-11-14)
 
 ## What's Changed
-* Fixed `Cannot read properties of undefined (reading 'updateCharacteristic')` on Bots. [#77](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/77)
-* Fixed Temperature not being retrieved for Switchbot Meter. [#78](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/78)
+
+- Fixed `Cannot read properties of undefined (reading 'updateCharacteristic')` on Bots. [#77](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/77)
+- Fixed Temperature not being retrieved for Switchbot Meter. [#78](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/78)
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.0.0...v1.0.1
 
 ## [Version 1.0.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.0.0) (2021-11-13)
 
 ## What's Changed
-* Offical release of homebridge-Switchbot, which combines both BLE and OpenAPI into 1 plugin.
-* Adds Light Sensors to Curtains
-    * with iOS 15.1 you can set automations on light sensors.
-* Adds Motion Sensor to Contact Sensors
-* Adds Support Color Bulbs
+
+- Offical release of homebridge-Switchbot, which combines both BLE and OpenAPI into 1 plugin.
+- Adds Light Sensors to Curtains
+  - with iOS 15.1 you can set automations on light sensors.
+- Adds Motion Sensor to Contact Sensors
+- Adds Support Color Bulbs
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v0.1.1...v1.0.0
 
 ## [Version 0.1.1](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v0.1.1) (2021-09-11)
 
 ## What's Changed
-* Fix Contact Sensor adding as Motion Sensor instead of Contact Sensor
+
+- Fix Contact Sensor adding as Motion Sensor instead of Contact Sensor
 
 **Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v0.1.0...v0.1.1
 
 ## [Version 0.1.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v0.1.0) (2021-09-10)
 
 ## What's Changed
-* Initial release of homebridge-switchbot.
-* Adds Support for Motion & Contact Sensors
-* Adds Water Level to Humidifier
+
+- Initial release of homebridge-switchbot.
+- Adds Support for Motion & Contact Sensors
+- Adds Water Level to Humidifier

--- a/config.schema.json
+++ b/config.schema.json
@@ -288,7 +288,7 @@
                       }
                     },
                     "doublePress": {
-                      "title": "Do you want to similate a double press?",
+                      "title": "How many presses do you want to simulate?",
                       "type": "number",
                       "placeholder": "2",
                       "condition": {
@@ -379,7 +379,7 @@
                       "type": "number",
                       "minimum": 1,
                       "placeholder": 5,
-                      "description": "Indicates the number of seconds between before refreshing Curtain status while updating slide progress.",
+                      "description": "Indicates the number of seconds before refreshing Curtain status while updating slide progress.",
                       "condition": {
                         "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Curtain' && model.options.devices[arrayIndices].deviceId);"
                       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@switchbot/homebridge-switchbot",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@switchbot/homebridge-switchbot",
-      "version": "1.12.1",
+      "version": "1.12.2",
       "funding": [
         {
           "type": "Paypal",
@@ -2194,9 +2194,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+      "version": "13.12.1",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
       "dev": true,
       "dependencies": {
         "type-fest": "^0.20.2"
@@ -7106,9 +7106,9 @@
       }
     },
     "globals": {
-      "version": "13.12.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.0.tgz",
-      "integrity": "sha512-uS8X6lSKN2JumVoXrbUz+uG4BYG+eiawqm3qFcT7ammfbUHeCBoJMlHcec/S3krSk73/AE/f0szYFmgAA3kYZg==",
+      "version": "13.12.1",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-13.12.1.tgz",
+      "integrity": "sha512-317dFlgY2pdJZ9rspXDks7073GpDmXdfbM3vYYp0HAMKGDh1FfWPleI2ljVNLQX5M5lXcAslTcPTrOrMEFOjyw==",
       "dev": true,
       "requires": {
         "type-fest": "^0.20.2"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge SwitchBot",
   "name": "@switchbot/homebridge-switchbot",
-  "version": "1.12.1",
+  "version": "1.12.2",
   "description": "The [Homebridge](https://homebridge.io) SwitchBot plugin allows you to access your [SwitchBot](https://www.switch-bot.com) device(s) from HomeKit.",
   "author": "SwitchBot <support@wondertechlabs.com> (https://github.com/SwitchBot)",
   "license": "ISC",

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -118,7 +118,7 @@ export class Curtain {
       })
       .onSet(this.TargetPositionSet.bind(this));
 
-    /* Light Sensor Service
+    // Light Sensor Service
     if (device.curtain?.hide_lightsensor) {
       this.debugLog(`Curtain: ${accessory.displayName} Removing Light Sensor Service`);
       this.lightSensorService = this.accessory.getService(this.platform.Service.LightSensor);
@@ -132,7 +132,7 @@ export class Curtain {
       this.lightSensorService.setCharacteristic(this.platform.Characteristic.Name, `${accessory.displayName} Light Sensor`);
     } else {
       this.debugLog(`Curtain: ${accessory.displayName} Light Sensor Service Not Added`);
-    }*/
+    }
 
     // Battery Service
     if (!device.ble) {

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -118,7 +118,7 @@ export class Curtain {
       })
       .onSet(this.TargetPositionSet.bind(this));
 
-    // Light Sensor Service
+    /* Light Sensor Service
     if (device.curtain?.hide_lightsensor) {
       this.debugLog(`Curtain: ${accessory.displayName} Removing Light Sensor Service`);
       this.lightSensorService = this.accessory.getService(this.platform.Service.LightSensor);
@@ -132,7 +132,7 @@ export class Curtain {
       this.lightSensorService.setCharacteristic(this.platform.Characteristic.Name, `${accessory.displayName} Light Sensor`);
     } else {
       this.debugLog(`Curtain: ${accessory.displayName} Light Sensor Service Not Added`);
-    }
+    }*/
 
     // Battery Service
     if (!device.ble) {

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -584,6 +584,7 @@ export class Curtain {
     if (this.PositionState === undefined) {
       this.debugLog(`Curtain: ${this.accessory.displayName} PositionState: ${this.PositionState}`);
     } else {
+      this.windowCoveringService.updateCharacteristic(this.platform.Characteristic.PositionState, Number(this.PositionState));
       this.debugLog(`Curtain: ${this.accessory.displayName} updateCharacteristic PositionState: ${this.PositionState}`);
     }
     if (this.TargetPosition === undefined || Number.isNaN(this.TargetPosition)) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -217,7 +217,9 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
         this.debugLog(JSON.stringify(devicesAPI));
 
         // SwitchBot Devices
-        this.infoLog(`Total SwitchBot Devices Found: ${devicesAPI.body.deviceList.length}`);
+        if (devicesAPI.body.deviceList.length !== 0) {
+          this.infoLog(`Total SwitchBot Devices Found: ${devicesAPI.body.deviceList.length}`);
+        }
         const deviceLists = devicesAPI.body.deviceList;
         if (!this.config.options?.devices) {
           this.debugLog(`SwitchBot Device Config Not Set: ${JSON.stringify(this.config.options?.devices)}`);
@@ -257,7 +259,9 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
           this.errorLog('Neither SwitchBot OpenToken or Device Config are not set.');
         }
         // IR Devices
-        this.infoLog(`Total IR Devices Found: ${devicesAPI.body.infraredRemoteList.length}`);
+        if (devicesAPI.body.infraredRemoteList.length !== 0) {
+          this.infoLog(`Total IR Devices Found: ${devicesAPI.body.infraredRemoteList.length}`);
+        }
         const irDeviceLists = devicesAPI.body.infraredRemoteList;
         if (!this.config.options?.irdevices) {
           this.debugLog(`IR Device Config Not Set: ${JSON.stringify(this.config.options?.irdevices)}`);

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -219,6 +219,8 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
         // SwitchBot Devices
         if (devicesAPI.body.deviceList.length !== 0) {
           this.infoLog(`Total SwitchBot Devices Found: ${devicesAPI.body.deviceList.length}`);
+        } else {
+          this.debugLog(`Total SwitchBot Devices Found: ${devicesAPI.body.deviceList.length}`);
         }
         const deviceLists = devicesAPI.body.deviceList;
         if (!this.config.options?.devices) {
@@ -261,6 +263,8 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
         // IR Devices
         if (devicesAPI.body.infraredRemoteList.length !== 0) {
           this.infoLog(`Total IR Devices Found: ${devicesAPI.body.infraredRemoteList.length}`);
+        } else {
+          this.debugLog(`Total IR Devices Found: ${devicesAPI.body.infraredRemoteList.length}`);
         }
         const irDeviceLists = devicesAPI.body.infraredRemoteList;
         if (!this.config.options?.irdevices) {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -117,7 +117,7 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
    * It should be used to setup event handlers for characteristics and update respective values.
    */
   configureAccessory(accessory: PlatformAccessory) {
-    this.infoLog(`Loading accessory from cache: ${accessory.displayName}`);
+    this.debugLog(`Loading accessory from cache: ${accessory.displayName}`);
 
     // add the restored accessory to the accessories cache so we can track if it has already been registered
     this.accessories.push(accessory);


### PR DESCRIPTION
## [Version 1.12.2](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v1.12.2) (2022-02-02)

## What's Changed

- Fix: Issue where `PositionState` was not being sent back to Home App. Fixes [#123](https://github.com/OpenWonderLabs/homebridge-switchbot/issues/123) Thanks [@dnicolson](https://github.com/dnicolson)!

**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v1.12.1...v1.12.2