### PR TITLE
Fixes #314 "Other" IR devices which are already off will now not toggle state when turned off

### DIFF
--- a/src/irdevice/other.ts
+++ b/src/irdevice/other.ts
@@ -64,9 +64,9 @@ export class Others {
   async ActiveSet(value: CharacteristicValue): Promise<void> {
     this.debugLog(`Other: ${this.accessory.displayName} On: ${value}`);
     if (value) {
-      await this.pushOffChanges();
-    } else {
       await this.pushOnChanges();
+    } else {
+      await this.pushOffChanges();
     }
     this.Active = value;
     this.ActiveCached = this.Active;

--- a/src/irdevice/other.ts
+++ b/src/irdevice/other.ts
@@ -63,7 +63,7 @@ export class Others {
 
   async ActiveSet(value: CharacteristicValue): Promise<void> {
     this.debugLog(`Other: ${this.accessory.displayName} On: ${value}`);
-    if (this.Active) {
+    if (value) {
       await this.pushOffChanges();
     } else {
       await this.pushOnChanges();
@@ -96,14 +96,12 @@ export class Others {
     if (this.platform.config.options) {
       if (this.device.other) {
         if (this.device.other.commandOn) {
-          if (!this.Active) {
-            const payload = {
-              commandType: 'customize',
-              parameter: 'default',
-              command: `${this.device.other.commandOn}`,
-            } as payload;
-            await this.pushChanges(payload);
-          }
+          const payload = {
+            commandType: 'customize',
+            parameter: 'default',
+            command: `${this.device.other.commandOn}`,
+          } as payload;
+          await this.pushChanges(payload);
         } else {
           this.errorLog(`Other: ${this.accessory.displayName} On Command not set, commandOn: ${this.device.other.commandOn}`);
         }
@@ -119,14 +117,12 @@ export class Others {
     if (this.platform.config.options) {
       if (this.device.other) {
         if (this.device.other.commandOff) {
-          if (this.Active) {
-            const payload = {
-              commandType: 'customize',
-              parameter: 'default',
-              command: `${this.device.other.commandOff}`,
-            } as payload;
-            await this.pushChanges(payload);
-          }
+          const payload = {
+            commandType: 'customize',
+            parameter: 'default',
+            command: `${this.device.other.commandOff}`,
+          } as payload;
+          await this.pushChanges(payload);
         } else {
           this.errorLog(`Other: ${this.accessory.displayName} Off Command not set, commandOff: ${this.device.other.commandOff}`);
         }


### PR DESCRIPTION
As per https://github.com/OpenWonderLabs/homebridge-switchbot/issues/314

This is a fix so that when an "Other" IR device is already off, telling it to turn off again will simply re-transmit the "off" command instead of toggling it to an "on" command.