### PR TITLE
Avoid sending redundant commands to "Other" IR devices

### DIFF
--- a/src/irdevice/other.ts
+++ b/src/irdevice/other.ts
@@ -64,9 +64,9 @@ export class Others {
   async ActiveSet(value: CharacteristicValue): Promise<void> {
     this.debugLog(`Other: ${this.accessory.displayName} On: ${value}`);
     if (value) {
-      await this.pushOffChanges();
-    } else {
       await this.pushOnChanges();
+    } else {
+      await this.pushOffChanges();
     }
     this.Active = value;
     this.ActiveCached = this.Active;

--- a/src/irdevice/other.ts
+++ b/src/irdevice/other.ts
@@ -96,12 +96,14 @@ export class Others {
     if (this.platform.config.options) {
       if (this.device.other) {
         if (this.device.other.commandOn) {
-          const payload = {
-            commandType: 'customize',
-            parameter: 'default',
-            command: `${this.device.other.commandOn}`,
-          } as payload;
-          await this.pushChanges(payload);
+          if (!this.Active) {
+            const payload = {
+              commandType: 'customize',
+              parameter: 'default',
+              command: `${this.device.other.commandOn}`,
+            } as payload;
+            await this.pushChanges(payload);
+          }
         } else {
           this.errorLog(`Other: ${this.accessory.displayName} On Command not set, commandOn: ${this.device.other.commandOn}`);
         }
@@ -117,12 +119,14 @@ export class Others {
     if (this.platform.config.options) {
       if (this.device.other) {
         if (this.device.other.commandOff) {
-          const payload = {
-            commandType: 'customize',
-            parameter: 'default',
-            command: `${this.device.other.commandOff}`,
-          } as payload;
-          await this.pushChanges(payload);
+          if (this.Active) {
+            const payload = {
+              commandType: 'customize',
+              parameter: 'default',
+              command: `${this.device.other.commandOff}`,
+            } as payload;
+            await this.pushChanges(payload);
+          }
         } else {
           this.errorLog(`Other: ${this.accessory.displayName} Off Command not set, commandOff: ${this.device.other.commandOff}`);
         }

--- a/src/irdevice/other.ts
+++ b/src/irdevice/other.ts
@@ -63,7 +63,7 @@ export class Others {
 
   async ActiveSet(value: CharacteristicValue): Promise<void> {
     this.debugLog(`Other: ${this.accessory.displayName} On: ${value}`);
-    if (this.Active) {
+    if (value) {
       await this.pushOffChanges();
     } else {
       await this.pushOnChanges();
@@ -96,14 +96,12 @@ export class Others {
     if (this.platform.config.options) {
       if (this.device.other) {
         if (this.device.other.commandOn) {
-          if (!this.Active) {
-            const payload = {
-              commandType: 'customize',
-              parameter: 'default',
-              command: `${this.device.other.commandOn}`,
-            } as payload;
-            await this.pushChanges(payload);
-          }
+          const payload = {
+            commandType: 'customize',
+            parameter: 'default',
+            command: `${this.device.other.commandOn}`,
+          } as payload;
+          await this.pushChanges(payload);
         } else {
           this.errorLog(`Other: ${this.accessory.displayName} On Command not set, commandOn: ${this.device.other.commandOn}`);
         }
@@ -119,14 +117,12 @@ export class Others {
     if (this.platform.config.options) {
       if (this.device.other) {
         if (this.device.other.commandOff) {
-          if (this.Active) {
-            const payload = {
-              commandType: 'customize',
-              parameter: 'default',
-              command: `${this.device.other.commandOff}`,
-            } as payload;
-            await this.pushChanges(payload);
-          }
+          const payload = {
+            commandType: 'customize',
+            parameter: 'default',
+            command: `${this.device.other.commandOff}`,
+          } as payload;
+          await this.pushChanges(payload);
         } else {
           this.errorLog(`Other: ${this.accessory.displayName} Off Command not set, commandOff: ${this.device.other.commandOff}`);
         }


### PR DESCRIPTION
## :recycle: Current situation

If an "Other" IR device receives a command to set its state to its current state, the IR signal is sent anyway - behaviour created in #315. @donavanbecker has indicated that redundant commands should not be sent.

## :bulb: Proposed solution

Only send on and off commands to devices not already in the target state.