### PR TITLE
Add support for Switchbot Lock

### DIFF
--- a/src/device/lock.ts
+++ b/src/device/lock.ts
@@ -171,8 +171,8 @@ export class Lock {
   /**
    * Pushes the requested changes to the SwitchBot API
    * deviceType	commandType	  Command	    command parameter	  Description
-   * Lock   -    "command"     "????"   "????"	  =        set to ???? state
-   * Lock   -    "command"     "????"    "????"	  =        set to ???? state - LockCurrentState
+   * Lock   -    "command"     "lock"     "default"	 =        set to ???? state
+   * Lock   -    "command"     "unlock"   "default"	 =        set to ???? state - LockCurrentState
    */
   async pushChanges(): Promise<void> {
     if (this.LockTargetState !== this.LockTargetStateCached) {
@@ -182,9 +182,9 @@ export class Lock {
       } as payload;
 
       if (this.LockTargetState) {
-        payload.command = 'turnOn';
+        payload.command = 'lock';
       } else {
-        payload.command = 'turnOff';
+        payload.command = 'unlock';
       }
 
       this.infoLog(


### PR DESCRIPTION
Add command to lock/unlock device

## :recycle: Current situation
You can only view the status of the Switchbot lock, you cannot control it.

## :bulb: Proposed solution
Added the correct command for the lock so that it can be locked/unlocked

## :gear: Release Notes
Added support for locking/unlocking the switchbot lock

## :heavy_plus_sign: Additional Information
Tested on my Switchbot lock at home. 

### Reviewer Nudging
Change is not very large, it was just changing the command from "turnOn" -> "lock" and "turnOff" -> "unlock"

Closes #226 