### PR TITLE
devices: Fix misleading firmware debug log messages

### DIFF
--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -1160,9 +1160,9 @@ export class Bot {
 
   FirmwareRevision(accessory: PlatformAccessory<Context>, device: device & devicesConfig): CharacteristicValue {
     let FirmwareRevision: string;
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
+    this.debugLog(`Bot: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
+    this.debugLog(`Bot: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
+    this.debugLog(`Bot: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
     if (accessory.context.FirmwareRevision) {
       FirmwareRevision = accessory.context.FirmwareRevision;
     } else if (device.firmware) {

--- a/src/device/contact.ts
+++ b/src/device/contact.ts
@@ -514,9 +514,9 @@ export class Contact {
 
   FirmwareRevision(accessory: PlatformAccessory<Context>, device: device & devicesConfig): CharacteristicValue {
     let FirmwareRevision: string;
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
+    this.debugLog(`Contact Sensor: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
+    this.debugLog(`Contact Sensor: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
+    this.debugLog(`Contact Sensor: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
     if (accessory.context.FirmwareRevision) {
       FirmwareRevision = accessory.context.FirmwareRevision;
     } else if (device.firmware) {

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -916,9 +916,9 @@ export class Curtain {
 
   FirmwareRevision(accessory: PlatformAccessory<Context>, device: device & devicesConfig): CharacteristicValue {
     let FirmwareRevision: string;
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
+    this.debugLog(`Curtain: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
+    this.debugLog(`Curtain: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
+    this.debugLog(`Curtain: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
     if (accessory.context.FirmwareRevision) {
       FirmwareRevision = accessory.context.FirmwareRevision;
     } else if (device.firmware) {

--- a/src/device/humidifier.ts
+++ b/src/device/humidifier.ts
@@ -816,9 +816,9 @@ export class Humidifier {
 
   FirmwareRevision(accessory: PlatformAccessory<Context>, device: device & devicesConfig): CharacteristicValue {
     let FirmwareRevision: string;
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
+    this.debugLog(`Humidifier: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
+    this.debugLog(`Humidifier: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
+    this.debugLog(`Humidifier: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
     if (accessory.context.FirmwareRevision) {
       FirmwareRevision = accessory.context.FirmwareRevision;
     } else if (device.firmware) {

--- a/src/device/lock.ts
+++ b/src/device/lock.ts
@@ -339,9 +339,9 @@ export class Lock {
 
   FirmwareRevision(accessory: PlatformAccessory<Context>, device: device & devicesConfig): CharacteristicValue {
     let FirmwareRevision: string;
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
+    this.debugLog(`Lock: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
+    this.debugLog(`Lock: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
+    this.debugLog(`Lock: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
     if (accessory.context.FirmwareRevision) {
       FirmwareRevision = accessory.context.FirmwareRevision;
     } else if (device.firmware) {

--- a/src/device/meter.ts
+++ b/src/device/meter.ts
@@ -542,9 +542,9 @@ export class Meter {
 
   FirmwareRevision(accessory: PlatformAccessory<Context>, device: device & devicesConfig): CharacteristicValue {
     let FirmwareRevision: string;
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
+    this.debugLog(`Meter: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
+    this.debugLog(`Meter: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
+    this.debugLog(`Meter: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
     if (accessory.context.FirmwareRevision) {
       FirmwareRevision = accessory.context.FirmwareRevision;
     } else if (device.firmware) {

--- a/src/device/meterplus.ts
+++ b/src/device/meterplus.ts
@@ -486,9 +486,9 @@ export class MeterPlus {
 
   FirmwareRevision(accessory: PlatformAccessory<Context>, device: device & devicesConfig): CharacteristicValue {
     let FirmwareRevision: string;
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
+    this.debugLog(`Meter Plus: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
+    this.debugLog(`Meter Plus: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
+    this.debugLog(`Meter Plus: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
     if (accessory.context.FirmwareRevision) {
       FirmwareRevision = accessory.context.FirmwareRevision;
     } else if (device.firmware) {

--- a/src/device/motion.ts
+++ b/src/device/motion.ts
@@ -458,9 +458,9 @@ export class Motion {
 
   FirmwareRevision(accessory: PlatformAccessory<Context>, device: device & devicesConfig): CharacteristicValue {
     let FirmwareRevision: string;
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
+    this.debugLog(`Motion Sensor: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
+    this.debugLog(`Motion Sensor: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
+    this.debugLog(`Motion Sensor: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
     if (accessory.context.FirmwareRevision) {
       FirmwareRevision = accessory.context.FirmwareRevision;
     } else if (device.firmware) {

--- a/src/device/plug.ts
+++ b/src/device/plug.ts
@@ -320,9 +320,9 @@ export class Plug {
 
   FirmwareRevision(accessory: PlatformAccessory<Context>, device: device & devicesConfig): CharacteristicValue {
     let FirmwareRevision: string;
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
+    this.debugLog(`Plug: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
+    this.debugLog(`Plug: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
+    this.debugLog(`Plug: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
     if (accessory.context.FirmwareRevision) {
       FirmwareRevision = accessory.context.FirmwareRevision;
     } else if (device.firmware) {

--- a/src/device/striplight.ts
+++ b/src/device/striplight.ts
@@ -542,9 +542,9 @@ export class StripLight {
 
   FirmwareRevision(accessory: PlatformAccessory<Context>, device: device & devicesConfig): CharacteristicValue {
     let FirmwareRevision: string;
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
-    this.debugLog(`Color Bulb: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
+    this.debugLog(`Strip Light: ${this.accessory.displayName} accessory.context.FirmwareRevision: ${accessory.context.FirmwareRevision}`);
+    this.debugLog(`Strip Light: ${this.accessory.displayName} device.firmware: ${device.firmware}`);
+    this.debugLog(`Strip Light: ${this.accessory.displayName} this.platform.version: ${this.platform.version}`);
     if (accessory.context.FirmwareRevision) {
       FirmwareRevision = accessory.context.FirmwareRevision;
     } else if (device.firmware) {


### PR DESCRIPTION
## :recycle: Current situation

All firmware version related debug log messages are currently prefixed by "Color Bulb" even if the device is something else which is, at least, confusing.

```
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi Using Platform Config Logging: debug
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi Using Device Config scanDuration: 15
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi Using Platform Config refreshRate: 120
[8/15/2022, 8:41:12 PM] [SwitchBot] Meter Plus: sb.WoZi Config: {"ble":true,"scanDuration":15}
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi BLE RefreshStatus
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Color Bulb: sb.WoZi accessory.context.FirmwareRevision: undefined
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Color Bulb: sb.WoZi device.firmware: undefined
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Color Bulb: sb.WoZi this.platform.version: 1.14.1
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Color Bulb: sb.WoZi accessory.context.FirmwareRevision: undefined
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Color Bulb: sb.WoZi device.firmware: undefined
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Color Bulb: sb.WoZi this.platform.version: 1.14.1
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi Add Temperature Sensor Service
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi Add Humidity Sensor Service
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi Add Battery Service
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi updateCharacteristic CurrentRelativeHumidity: 0
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi updateCharacteristic CurrentTemperature: 0
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi BatteryLevel: undefined
[8/15/2022, 8:41:12 PM] [SwitchBot] [DEBUG] Meter Plus: sb.WoZi StatusLowBattery: undefined
```

## :bulb: Proposed solution

Change them to refer to the correct device type instead.

## :gear: Release Notes

Fix misleading firmware debug log messages referring to "Color Bulb" instead of the correct device type.