### PR TITLE
Fixes #520, IR Commands not sent from "Other" IR Devices

### DIFF
--- a/src/irdevice/other.ts
+++ b/src/irdevice/other.ts
@@ -64,13 +64,20 @@ export class Others {
 
   async ActiveSet(value: CharacteristicValue): Promise<void> {
     this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} On: ${value}`);
-    this.Active = value;
-    this.accessory.context.Active = this.Active;
     if (value) {
       await this.pushOnChanges();
     } else {
       await this.pushOffChanges();
     }
+    
+    /*
+    pushOnChanges and pushOffChanges above assume they are measuring the state of the accessory BEFORE
+    they are updated, so we are only updating the accessory state after calling the above.
+    */
+    
+    this.Active = value;
+    this.accessory.context.Active = this.Active;
+
   }
 
   /**


### PR DESCRIPTION
## :recycle: Current situation

The Active state of the device was being updated before calling the pushOnChanges() and PushOffChanges() functions, and those functions internally assume that they are checking for the state of the device _before_ updates occur.

## :bulb: Proposed solution

The active state of the device is now updated after calling the pushXXXChanges() functions, and I have left a comment as to why so that future contributors are aware of the fragile arrangement.

## :gear: Release Notes

Fixes an issue that caused "Other" IR Devices to not properly send signals.

### Testing

Are there tests? 😆

