### PR TITLE
`allowPush` support for IR Devices

### DIFF
--- a/src/irdevice/airpurifier.ts
+++ b/src/irdevice/airpurifier.ts
@@ -38,6 +38,7 @@ export class AirPurifier {
 
   // Config
   deviceLogging!: string;
+  allowPush?: boolean;
 
   constructor(private readonly platform: SwitchBotPlatform, private accessory: PlatformAccessory, public device: irdevice & irDevicesConfig) {
     // default placeholders
@@ -130,7 +131,7 @@ export class AirPurifier {
    * AirPurifier:        "command"       "highSpeed"      "default"	        =        fan speed to high
    */
   async pushAirPurifierOnChanges(): Promise<void> {
-    if (this.Active !== 1) {
+    if (this.Active !== 1 || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOn();
       const body = superStringify({
@@ -145,7 +146,7 @@ export class AirPurifier {
   async pushAirPurifierOffChanges(): Promise<void> {
     const commandType: string = await this.commandType();
     const command: string = await this.commandOff();
-    if (this.Active !== 0) {
+    if (this.Active !== 0 || this.allowPush) {
       const body = superStringify({
         'command': command,
         'parameter': 'default',

--- a/src/irdevice/camera.ts
+++ b/src/irdevice/camera.ts
@@ -20,6 +20,7 @@ export class Camera {
 
   // Config
   deviceLogging!: string;
+  allowPush?: boolean;
 
   constructor(private readonly platform: SwitchBotPlatform, private accessory: PlatformAccessory, public device: irdevice & irDevicesConfig) {
     // default placeholders
@@ -80,7 +81,7 @@ export class Camera {
    * Camera -        "command"       "channelSub"      "default"	        =        previous channel
    */
   async pushOnChanges(): Promise<void> {
-    if (this.On) {
+    if (this.On || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOn();
       const body = superStringify({
@@ -95,7 +96,7 @@ export class Camera {
   async pushOffChanges(): Promise<void> {
     const commandType: string = await this.commandType();
     const command: string = await this.commandOff();
-    if (!this.On) {
+    if (!this.On || this.allowPush) {
       const body = superStringify({
         'command': command,
         'parameter': 'default',

--- a/src/irdevice/fan.ts
+++ b/src/irdevice/fan.ts
@@ -184,7 +184,7 @@ export class Fan {
   }
 
   async pushFanOffChanges(): Promise<void> {
-    if (this.Active == 1 || this.allowPush) {
+    if (this.Active === 1 || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOff();
       const body = superStringify({

--- a/src/irdevice/fan.ts
+++ b/src/irdevice/fan.ts
@@ -30,6 +30,7 @@ export class Fan {
   minValue?: number;
   maxValue?: number;
   deviceLogging!: string;
+  allowPush?: boolean;
 
   constructor(private readonly platform: SwitchBotPlatform, private accessory: PlatformAccessory, public device: irdevice & irDevicesConfig) {
     // default placeholders
@@ -169,8 +170,8 @@ export class Fan {
    * Fan -        "command"       "middleSpeed"    "default"	        =        fan speed to medium
    * Fan -        "command"       "highSpeed"      "default"	        =        fan speed to high
    */
-  async pushFanOnChanges(): Promise<void> {
-    if (this.Active !== 1) {
+  async pushFanOffChanges(): Promise<void> {
+    if (this.Active !== 1 || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOn();
       const body = superStringify({
@@ -183,14 +184,16 @@ export class Fan {
   }
 
   async pushFanOffChanges(): Promise<void> {
-    const commandType: string = await this.commandType();
-    const command: string = await this.commandOff();
-    const body = superStringify({
-      'command': command,
-      'parameter': 'default',
-      'commandType': commandType,
-    });
-    await this.pushTVChanges(body);
+    if (this.Active == 1 || this.allowPush) {
+      const commandType: string = await this.commandType();
+      const command: string = await this.commandOff();
+      const body = superStringify({
+        'command': command,
+        'parameter': 'default',
+        'commandType': commandType,
+      });
+      await this.pushTVChanges(body);
+    }
   }
 
   async pushFanSpeedUpChanges(): Promise<void> {

--- a/src/irdevice/light.ts
+++ b/src/irdevice/light.ts
@@ -20,6 +20,7 @@ export class Light {
 
   // Config
   deviceLogging!: string;
+  allowPush?: boolean;
 
   constructor(private readonly platform: SwitchBotPlatform, private accessory: PlatformAccessory, public device: irdevice & irDevicesConfig) {
     // default placeholders
@@ -80,7 +81,7 @@ export class Light {
    * Light -       "command"       "channelSub"      "default"	        =        previous channel
    */
   async pushLightOnChanges(): Promise<void> {
-    if (this.On) {
+    if (this.On || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOn();
       const body = superStringify({
@@ -93,7 +94,7 @@ export class Light {
   }
 
   async pushLightOffChanges(): Promise<void> {
-    if (!this.On) {
+    if (!this.On || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOff();
       const body = superStringify({

--- a/src/irdevice/other.ts
+++ b/src/irdevice/other.ts
@@ -21,6 +21,7 @@ export class Others {
   // Config
   deviceLogging!: string;
   otherDeviceType?: string;
+  allowPush?: boolean;
 
   constructor(private readonly platform: SwitchBotPlatform, private accessory: PlatformAccessory, public device: irdevice & irDevicesConfig) {
     // default placeholders
@@ -89,7 +90,7 @@ export class Others {
    */
   async pushOnChanges(): Promise<void> {
     if (this.device.customize) {
-      if (!this.Active) {
+      if (!this.Active || this.allowPush) {
         const commandType: string = await this.commandType();
         const command: string = await this.commandOn();
         const body = superStringify({
@@ -106,7 +107,7 @@ export class Others {
 
   async pushOffChanges(): Promise<void> {
     if (this.device.customize) {
-      if (this.Active) {
+      if (this.Active || this.allowPush) {
         const commandType: string = await this.commandType();
         const command: string = await this.commandOff();
         const body = superStringify({

--- a/src/irdevice/tv.ts
+++ b/src/irdevice/tv.ts
@@ -25,6 +25,7 @@ export class TV {
 
   // Config
   deviceLogging!: string;
+  allowPush?: boolean;
 
   constructor(private readonly platform: SwitchBotPlatform, private accessory: PlatformAccessory, public device: irdevice & irDevicesConfig) {
     // default placeholders
@@ -226,7 +227,7 @@ export class TV {
    * TV           "command"       "channelSub"      "default"	        previous channel
    */
   async pushTvOnChanges(): Promise<void> {
-    if (this.Active !== 1) {
+    if (this.Active !== 1 || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOn();
       const body = superStringify({
@@ -239,14 +240,16 @@ export class TV {
   }
 
   async pushTvOffChanges(): Promise<void> {
-    const commandType: string = await this.commandType();
-    const command: string = await this.commandOff();
-    const body = superStringify({
-      'command': command,
-      'parameter': 'default',
-      'commandType': commandType,
-    });
-    await this.pushTVChanges(body);
+    if (this.Active == 1 || this.allowPush) {
+      const commandType: string = await this.commandType();
+      const command: string = await this.commandOff();
+      const body = superStringify({
+        'command': command,
+        'parameter': 'default',
+        'commandType': commandType,
+      });
+      await this.pushTVChanges(body);
+    }
   }
 
   async pushOkChanges(): Promise<void> {

--- a/src/irdevice/tv.ts
+++ b/src/irdevice/tv.ts
@@ -240,7 +240,7 @@ export class TV {
   }
 
   async pushTvOffChanges(): Promise<void> {
-    if (this.Active == 1 || this.allowPush) {
+    if (this.Active === 1 || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOff();
       const body = superStringify({

--- a/src/irdevice/vacuumcleaner.ts
+++ b/src/irdevice/vacuumcleaner.ts
@@ -20,6 +20,7 @@ export class VacuumCleaner {
 
   // Config
   deviceLogging!: string;
+  allowPush?: boolean;
 
   constructor(private readonly platform: SwitchBotPlatform, private accessory: PlatformAccessory, public device: irdevice & irDevicesConfig) {
     // default placeholders
@@ -76,7 +77,7 @@ export class VacuumCleaner {
    * Vacuum Cleaner    "command"       "turnOn"       "default"	      set to ON state
    */
   async pushOnChanges(): Promise<void> {
-    if (this.On) {
+    if (this.On || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOn();
       const body = superStringify({
@@ -89,7 +90,7 @@ export class VacuumCleaner {
   }
 
   async pushOffChanges(): Promise<void> {
-    if (!this.On) {
+    if (!this.On || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOff();
       const body = superStringify({

--- a/src/irdevice/waterheater.ts
+++ b/src/irdevice/waterheater.ts
@@ -21,6 +21,7 @@ export class WaterHeater {
 
   // Config
   deviceLogging!: string;
+  allowPush?: boolean;
 
   constructor(private readonly platform: SwitchBotPlatform, private accessory: PlatformAccessory, public device: irdevice & irDevicesConfig) {
     // default placeholders
@@ -82,7 +83,7 @@ export class WaterHeater {
    * WaterHeater     "command"       "turnOn"          "default"	       set to ON state
    */
   async pushWaterHeaterOnChanges(): Promise<void> {
-    if (this.Active !== 1) {
+    if (this.Active !== 1 || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOn();
       const body = superStringify({
@@ -95,7 +96,7 @@ export class WaterHeater {
   }
 
   async pushWaterHeaterOffChanges(): Promise<void> {
-    if (this.Active !== 0) {
+    if (this.Active !== 0 || this.allowPush) {
       const commandType: string = await this.commandType();
       const command: string = await this.commandOff();
       const body = superStringify({


### PR DESCRIPTION
## :recycle: Current situation

Currently, IR Devices do not send signals if their target devices are already in the desired state from Homebridge's perspective.

## :bulb: Proposed solution

IR Devices, apart from Air Conditioners which have their own complex governing logic for transmission, now support sending IR commands even if the target device is already in the desired state from Homebridge's perspective.

## :gear: Release Notes

(Dependent on UI implementation / documentation to allow users set the allowPush property appropriately)

Added `allowPush` property and logic, to allow IR commands to be sent even if a device is already in the state to be pushed.

This is a follow-up to issue #310 