### PR TITLE
Fix for the missing temperature value

### DIFF
--- a/src/device/meterplus.ts
+++ b/src/device/meterplus.ts
@@ -211,11 +211,12 @@ export class MeterPlus {
 
     // Current Temperature
     if (!this.device.meter?.hide_temperature) {
-      this.celsius < 0 ? 0 : this.celsius > 100 ? 100 : this.temperature;
+      this.temperature < 0 ? 0 : this.temperature > 100 ? 100 : this.temperature;
       this.CurrentTemperature = this.temperature;
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Temperature: ${this.CurrentTemperature}°c`);
     }
   }
+
 
   async openAPIparseStatus(): Promise<void> {
     this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} openAPIparseStatus`);


### PR DESCRIPTION
This should fix the issue where the Meter Plus doesn't update/retrieve the temperature value in Celsius and generates this warning log:

`This plugin generated a warning from the characteristic 'Current Temperature': characteristic value expected valid finite number and received "[object Object]"`

Anyway I don't know what can happen using Fahrenheit.