### PR TITLE
Replace switchbot wait with utility function

### DIFF
--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -8,6 +8,7 @@ import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 import { device, devicesConfig, deviceStatus, ad, serviceData, switchbot, HostDomain, DevicePath } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -659,7 +660,6 @@ export class Bot {
             this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
             return await this.retry({
               max: await this.maxRetry(),
-              switchbot,
               fn: () => {
                 if (this.On) {
                   return device_list[0].turnOn({ id: this.device.bleMac });
@@ -1172,15 +1172,15 @@ export class Bot {
     }
   }
 
-  async retry({ max, switchbot, fn }: { max: number; switchbot: any, fn: { (): any; (): Promise<any> } }): Promise<null> {
+  async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
     return fn().catch(async (err: any) => {
       if (max === 0) {
         throw err;
       }
       this.infoLog(err);
       this.infoLog('Retrying');
-      await switchbot.wait(1000);
-      return this.retry({ max: max - 1, switchbot, fn });
+      await sleep(1000);
+      return this.retry({ max: max - 1, fn });
     });
   }
 

--- a/src/device/ceilinglight.ts
+++ b/src/device/ceilinglight.ts
@@ -8,6 +8,7 @@ import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
 import { Service, PlatformAccessory, CharacteristicValue, ControllerConstructor, Controller, ControllerServiceMap } from 'homebridge';
 import { device, devicesConfig, deviceStatus, switchbot, hs2rgb, rgb2hs, m2hs, serviceData, ad, HostDomain, DevicePath } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -492,7 +493,6 @@ export class CeilingLight {
           this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
           return await this.retry({
             max: await this.maxRetry(),
-            switchbot,
             fn: () => {
               if (this.On) {
                 return device_list[0].turnOn({ id: this.device.bleMac });
@@ -965,15 +965,15 @@ export class CeilingLight {
     }
   }
 
-  async retry({ max, switchbot, fn }: { max: number; switchbot: any, fn: { (): any; (): Promise<any> } }): Promise<null> {
+  async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
     return fn().catch(async (err: any) => {
       if (max === 0) {
         throw err;
       }
       this.infoLog(err);
       this.infoLog('Retrying');
-      await switchbot.wait(1000);
-      return this.retry({ max: max - 1, switchbot, fn });
+      await sleep(1000);
+      return this.retry({ max: max - 1, fn });
     });
   }
 

--- a/src/device/colorbulb.ts
+++ b/src/device/colorbulb.ts
@@ -8,6 +8,7 @@ import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
 import { Service, PlatformAccessory, CharacteristicValue, ControllerConstructor, Controller, ControllerServiceMap } from 'homebridge';
 import { device, devicesConfig, deviceStatus, switchbot, hs2rgb, rgb2hs, m2hs, serviceData, ad, HostDomain, DevicePath } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -527,7 +528,6 @@ export class ColorBulb {
           this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
           return await this.retry({
             max: await this.maxRetry(),
-            switchbot,
             fn: () => {
               if (this.On) {
                 return device_list[0].turnOn({ id: this.device.bleMac });
@@ -1122,15 +1122,15 @@ export class ColorBulb {
     }
   }
 
-  async retry({ max, switchbot, fn }: { max: number; switchbot: any, fn: { (): any; (): Promise<any> } }): Promise<null> {
+  async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
     return fn().catch(async (err: any) => {
       if (max === 0) {
         throw err;
       }
       this.infoLog(err);
       this.infoLog('Retrying');
-      await switchbot.wait(1000);
-      return this.retry({ max: max - 1, switchbot, fn });
+      await sleep(1000);
+      return this.retry({ max: max - 1, fn });
     });
   }
 

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -10,6 +10,7 @@ import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 import { device, devicesConfig, serviceData, switchbot, deviceStatus, ad, HostDomain, DevicePath } from '../settings';
+import { sleep } from '../utils';
 
 export class Curtain {
   // Services
@@ -572,7 +573,6 @@ export class Curtain {
             this.infoLog(`${this.accessory.displayName} Target Position: ${this.TargetPosition}`);
             return await this.retry({
               max: await this.maxRetry(),
-              switchbot,
               fn: () => {
                 return device_list[0].runToPos(100 - Number(this.TargetPosition), adjustedMode);
               },
@@ -598,15 +598,15 @@ export class Curtain {
     }
   }
 
-  async retry({ max, switchbot, fn }: { max: number; switchbot: any, fn: { (): any; (): Promise<any> } }): Promise<null> {
+  async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
     return fn().catch(async (err: any) => {
       if (max === 0) {
         throw err;
       }
       this.infoLog(err);
       this.infoLog('Retrying');
-      await switchbot.wait(1000);
-      return this.retry({ max: max - 1, switchbot, fn });
+      await sleep(1000);
+      return this.retry({ max: max - 1, fn });
     });
   }
 

--- a/src/device/plug.ts
+++ b/src/device/plug.ts
@@ -8,6 +8,7 @@ import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 import { device, devicesConfig, deviceStatus, ad, serviceData, switchbot, HostDomain, DevicePath } from '../settings';
+import { sleep } from '../utils';
 
 export class Plug {
   // Services
@@ -351,7 +352,6 @@ export class Plug {
           this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
           return await this.retry({
             max: await this.maxRetry(),
-            switchbot,
             fn: () => {
               if (this.On) {
                 return device_list[0].turnOn({ id: this.device.bleMac });
@@ -521,15 +521,15 @@ export class Plug {
     }
   }
 
-  async retry({ max, switchbot, fn }: { max: number; switchbot: any, fn: { (): any; (): Promise<any> } }): Promise<null> {
+  async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
     return fn().catch(async (err: any) => {
       if (max === 0) {
         throw err;
       }
       this.infoLog(err);
       this.infoLog('Retrying');
-      await switchbot.wait(1000);
-      return this.retry({ max: max - 1, switchbot, fn });
+      await sleep(1000);
+      return this.retry({ max: max - 1, fn });
     });
   }
 

--- a/src/device/robotvacuumcleaner.ts
+++ b/src/device/robotvacuumcleaner.ts
@@ -8,6 +8,7 @@ import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
 import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
 import { device, devicesConfig, deviceStatus, ad, serviceData, switchbot, HostDomain, DevicePath } from '../settings';
+import { sleep } from '../utils';
 
 export class RobotVacuumCleaner {
   // Services
@@ -362,7 +363,6 @@ export class RobotVacuumCleaner {
           this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
           return await this.retry({
             max: await this.maxRetry(),
-            switchbot,
             fn: () => {
               if (this.On) {
                 return device_list[0].turnOn({ id: this.device.bleMac });
@@ -645,15 +645,15 @@ export class RobotVacuumCleaner {
     }
   }
 
-  async retry({ max, switchbot, fn }: { max: number; switchbot: any, fn: { (): any; (): Promise<any> } }): Promise<null> {
+  async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
     return fn().catch(async (err: any) => {
       if (max === 0) {
         throw err;
       }
       this.infoLog(err);
       this.infoLog('Retrying');
-      await switchbot.wait(1000);
-      return this.retry({ max: max - 1, switchbot, fn });
+      await sleep(1000);
+      return this.retry({ max: max - 1, fn });
     });
   }
 

--- a/src/device/striplight.ts
+++ b/src/device/striplight.ts
@@ -8,6 +8,7 @@ import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
 import { Service, PlatformAccessory, CharacteristicValue, ControllerConstructor, Controller, ControllerServiceMap } from 'homebridge';
 import { device, devicesConfig, switchbot, hs2rgb, rgb2hs, deviceStatus, HostDomain, DevicePath, ad, serviceData, m2hs } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -467,7 +468,6 @@ export class StripLight {
           this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
           return await this.retry({
             max: await this.maxRetry(),
-            switchbot,
             fn: () => {
               if (this.On) {
                 return device_list[0].turnOn({ id: this.device.bleMac });
@@ -886,15 +886,15 @@ export class StripLight {
     }
   }
 
-  async retry({ max, switchbot, fn }: { max: number; switchbot: any, fn: { (): any; (): Promise<any> } }): Promise<null> {
+  async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
     return fn().catch(async (err: any) => {
       if (max === 0) {
         throw err;
       }
       this.infoLog(err);
       this.infoLog('Retrying');
-      await switchbot.wait(1000);
-      return this.retry({ max: max - 1, switchbot, fn });
+      await sleep(1000);
+      return this.retry({ max: max - 1, fn });
     });
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,0 +1,3 @@
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}


### PR DESCRIPTION
## :recycle: Current situation

The `switchbot` object is passed as an argument for non-specific Switchbot functionality.

## :bulb: Proposed solution

Use a utility function instead that is not bound to the `switchbot` package, this can result in less unneeded code.

Only the curtain device has been changed for now. If this change is accepted, it can then be used for other devices.

## :heavy_plus_sign: Additional Information
Curtain failures result in the following error, it is not clear which package the error is from:
```
TypeError: Cannot read properties of null (reading 'write')
```