### PR TITLE
Catch curtain errors

### DIFF
--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -573,8 +573,12 @@ export class Curtain {
             return await this.retry({
               max: await this.maxRetry(),
               switchbot,
-              fn: () => {
-                return device_list[0].runToPos(100 - Number(this.TargetPosition), adjustedMode);
+              fn: async () => {
+                try {
+                  return await device_list[0].runToPos(100 - Number(this.TargetPosition), adjustedMode);
+                } catch(e: any) {
+                  throw new Error('Connection error');
+                }
               },
             });
           })


### PR DESCRIPTION
## :recycle: Current situation

The `node-switchbot` package can return a promise rejection [here](https://github.com/OpenWonderLabs/node-switchbot/blob/c38eba8/lib/switchbot-device-wocurtain.js#L91) that is not handled.

This can result in an error message being parsed as device data. As a consequence, the following error message can occur:
```
[@switchbot/homebridge-switchbot] This plugin generated a warning from the characteristic 'Battery Level': characteristic value expected valid finite number and received "NaN" (number). See https://homebridge.io/w/JtMGR for more info.
```

## :bulb: Proposed solution

Catch the rejection.