### PR TITLE
Fix opening and closing curtain states

### DIFF
--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -245,9 +245,6 @@ export class Curtain {
     this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} CurrentPosition ${this.CurrentPosition}`);
     if (this.setNewTarget) {
       this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} Checking Status ...`);
-    }
-
-    if (this.setNewTarget && this.inMotion) {
       await this.setMinMax();
       if (this.TargetPosition > this.CurrentPosition) {
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Closing, CurrentPosition: ${this.CurrentPosition}`);


### PR DESCRIPTION
## :recycle: Current situation

The "Opening…" and "Closing…" states no longer appear after https://github.com/OpenWonderLabs/homebridge-switchbot/pull/540 because the value of `inMotion` is always false.

## :bulb: Proposed solution

Remove `inMotion` condition.

There is still an issue getting the advertisement data after changing the curtain state, Homebridge needs to be restarted to get accurate advertisement data.
