### PR TITLE
Remove incorrect warning message

### DIFF
--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -963,10 +963,6 @@ export class Curtain {
     } else {
       if (this.updateRate > 1) {
         this.scanDuration = this.updateRate;
-        if (this.BLE) {
-          this.warnLog(`${this.device.deviceType}: `
-        + `${this.accessory.displayName} scanDuration is less then updateRate, overriding scanDuration with updateRate`);
-        }
       } else {
         this.scanDuration = this.accessory.context.scanDuration = 1;
       }

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -952,7 +952,7 @@ export class Curtain {
         this.scanDuration = this.updateRate;
         if (this.BLE) {
           this.warnLog(`${this.device.deviceType}: `
-        + `${this.accessory.displayName} scanDuration is less then updateRate, overriding scanDuration with updateRate`);
+        + `${this.accessory.displayName} scanDuration is less than updateRate, overriding scanDuration with updateRate`);
         }
       } else {
         this.scanDuration = this.accessory.context.scanDuration = device.scanDuration;


### PR DESCRIPTION
## :recycle: Current situation

An incorrect warning message is logged, `scanDuration` is referenced in a condition that is not possible.

## :bulb: Proposed solution

Remove logging and fix a typo.

Fixes #635.