### PR TITLE
Fixes mappingMode not being read from the config directly

### DIFF
--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -96,7 +96,7 @@ export class BlindTilt {
     this.setupMqtt(device);
     this.context();
 
-    this.mappingMode = (device.blindTilt?.mappingMode as BlindTiltMappingMode) ?? BlindTiltMappingMode.OnlyUp;
+    this.mappingMode = (device.blindTilt?.mode as BlindTiltMappingMode) ?? BlindTiltMappingMode.OnlyUp;
     this.debugLog(`Mapping mode: ${this.mappingMode}`);
 
     // this is subject we use to track when we need to POST changes to the SwitchBot API
@@ -1312,10 +1312,10 @@ export class BlindTilt {
       config['maxRetry'] = device.maxRetry;
     }
 
-    if(device.blindTilt?.mappingMode === undefined) {
-      config['mappingMode'] = BlindTiltMappingMode.OnlyUp;
+    if(device.blindTilt?.mode === undefined) {
+      config['mode'] = BlindTiltMappingMode.OnlyUp;
     } else {
-      config['mappingMode'] = device.blindTilt?.mappingMode;
+      config['mode'] = device.blindTilt?.mode;
     }
 
     if (Object.entries(config).length !== 0) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -107,7 +107,7 @@ export type curtain = {
 };
 
 export type blindTilt = {
-  mappingMode?: string;
+  mode?: string;
   updateRate?: number;
 };
 


### PR DESCRIPTION
The config calls it `mode` while the code calls it `mappingMode`. Renaming the config in code will make it work for new users without the need to reconfigure things