### PR TITLE
Remove incorrect warning message

### DIFF
--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -1043,10 +1043,6 @@ export class BlindTilt {
     } else {
       if (this.updateRate > 1) {
         this.scanDuration = this.updateRate;
-        if (this.BLE) {
-          this.warnLog(`${this.device.deviceType}: `
-        + `${this.accessory.displayName} scanDuration is less then updateRate, overriding scanDuration with updateRate`);
-        }
       } else {
         this.scanDuration = this.accessory.context.scanDuration = 1;
       }

--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -1032,7 +1032,7 @@ export class BlindTilt {
         this.scanDuration = this.updateRate;
         if (this.BLE) {
           this.warnLog(`${this.device.deviceType}: `
-        + `${this.accessory.displayName} scanDuration is less then updateRate, overriding scanDuration with updateRate`);
+        + `${this.accessory.displayName} scanDuration is less than updateRate, overriding scanDuration with updateRate`);
         }
       } else {
         this.scanDuration = this.accessory.context.scanDuration = device.scanDuration;


### PR DESCRIPTION
## :recycle: Current situation

An incorrect warning message is logged, `scanDuration` is referenced in a condition that is not possible.

## :bulb: Proposed solution

Remove logging and fix a typo.

Based on #661.