### PR TITLE
Remove unneeded async

### DIFF
--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -920,7 +920,7 @@ export class BlindTilt {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -1130,7 +1130,7 @@ export class Bot {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/ceilinglight.ts
+++ b/src/device/ceilinglight.ts
@@ -922,7 +922,7 @@ export class CeilingLight {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/colorbulb.ts
+++ b/src/device/colorbulb.ts
@@ -1079,7 +1079,7 @@ export class ColorBulb {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/contact.ts
+++ b/src/device/contact.ts
@@ -470,7 +470,7 @@ export class Contact {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -846,7 +846,7 @@ export class Curtain {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/humidifier.ts
+++ b/src/device/humidifier.ts
@@ -771,7 +771,7 @@ export class Humidifier {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/lock.ts
+++ b/src/device/lock.ts
@@ -513,7 +513,7 @@ export class Lock {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/meter.ts
+++ b/src/device/meter.ts
@@ -495,7 +495,7 @@ export class Meter {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/meterplus.ts
+++ b/src/device/meterplus.ts
@@ -495,7 +495,7 @@ export class MeterPlus {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/motion.ts
+++ b/src/device/motion.ts
@@ -420,7 +420,7 @@ export class Motion {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/plug.ts
+++ b/src/device/plug.ts
@@ -471,7 +471,7 @@ export class Plug {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/robotvacuumcleaner.ts
+++ b/src/device/robotvacuumcleaner.ts
@@ -595,7 +595,7 @@ export class RobotVacuumCleaner {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();

--- a/src/device/striplight.ts
+++ b/src/device/striplight.ts
@@ -843,7 +843,7 @@ export class StripLight {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();


### PR DESCRIPTION
## :recycle: Current situation

The `await` keyword is used for `stopScan` calls but it is a [synchronous method](https://github.com/OpenWonderLabs/node-switchbot#stopscan-method).

## :bulb: Proposed solution

Remove the `await` keyword.
