### PR TITLE
Fix async method calls

### DIFF
--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -614,8 +614,8 @@ export class BlindTilt {
             this.infoLog(`${this.accessory.displayName} Target Position: ${this.TargetPosition}`);
             return await this.retry({
               max: await this.maxRetry(),
-              fn: () => {
-                return device_list[0].runToPos(100 - Number(this.TargetPosition), adjustedMode);
+              fn: async () => {
+                return await device_list[0].runToPos(100 - Number(this.TargetPosition), adjustedMode);
               },
             });
           })

--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -640,11 +640,11 @@ export class BlindTilt {
   }
 
   async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
-    return fn().catch(async (err: any) => {
+    return fn().catch(async (e: any) => {
       if (max === 0) {
-        throw err;
+        throw e;
       }
-      this.infoLog(err);
+      this.infoLog(e);
       this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} Retrying`);
       await sleep(1000);
       return this.retry({ max: max - 1, fn });

--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -630,9 +630,9 @@ export class Bot {
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Bot Mode: ${this.botMode}`);
         switchbot
           .discover({ model: 'H', quick: true, id: this.device.bleMac })
-          .then((device_list: { press: (arg0: { id: string | undefined }) => any }[]) => {
+          .then(async (device_list: { press: (arg0: { id: string | undefined }) => any }[]) => {
             this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
-            return device_list[0].press({ id: this.device.bleMac });
+            return await device_list[0].press({ id: this.device.bleMac });
           })
           .then(() => {
             this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Done.`);
@@ -660,11 +660,11 @@ export class Bot {
             this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
             return await this.retry({
               max: await this.maxRetry(),
-              fn: () => {
+              fn: async () => {
                 if (this.On) {
-                  return device_list[0].turnOn({ id: this.device.bleMac });
+                  return await device_list[0].turnOn({ id: this.device.bleMac });
                 } else {
-                  return device_list[0].turnOff({ id: this.device.bleMac });
+                  return await device_list[0].turnOff({ id: this.device.bleMac });
                 }
               },
             });

--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -1173,11 +1173,11 @@ export class Bot {
   }
 
   async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
-    return fn().catch(async (err: any) => {
+    return fn().catch(async (e: any) => {
       if (max === 0) {
-        throw err;
+        throw e;
       }
-      this.infoLog(err);
+      this.infoLog(e);
       this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} Retrying`);
       await sleep(1000);
       return this.retry({ max: max - 1, fn });

--- a/src/device/ceilinglight.ts
+++ b/src/device/ceilinglight.ts
@@ -966,11 +966,11 @@ export class CeilingLight {
   }
 
   async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
-    return fn().catch(async (err: any) => {
+    return fn().catch(async (e: any) => {
       if (max === 0) {
-        throw err;
+        throw e;
       }
-      this.infoLog(err);
+      this.infoLog(e);
       this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} Retrying`);
       await sleep(1000);
       return this.retry({ max: max - 1, fn });

--- a/src/device/ceilinglight.ts
+++ b/src/device/ceilinglight.ts
@@ -493,11 +493,11 @@ export class CeilingLight {
           this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
           return await this.retry({
             max: await this.maxRetry(),
-            fn: () => {
+            fn: async () => {
               if (this.On) {
-                return device_list[0].turnOn({ id: this.device.bleMac });
+                return await device_list[0].turnOn({ id: this.device.bleMac });
               } else {
-                return device_list[0].turnOff({ id: this.device.bleMac });
+                return await device_list[0].turnOff({ id: this.device.bleMac });
               }
             },
           });

--- a/src/device/colorbulb.ts
+++ b/src/device/colorbulb.ts
@@ -528,11 +528,11 @@ export class ColorBulb {
           this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
           return await this.retry({
             max: await this.maxRetry(),
-            fn: () => {
+            fn: async () => {
               if (this.On) {
-                return device_list[0].turnOn({ id: this.device.bleMac });
+                return await device_list[0].turnOn({ id: this.device.bleMac });
               } else {
-                return device_list[0].turnOff({ id: this.device.bleMac });
+                return await device_list[0].turnOff({ id: this.device.bleMac });
               }
             },
           });
@@ -580,9 +580,9 @@ export class ColorBulb {
           model: 'u',
           id: this.device.bleMac,
         })
-        .then((device_list: any) => {
+        .then(async (device_list: any) => {
           this.infoLog(`${this.accessory.displayName} Target Brightness: ${this.Brightness}`);
-          return device_list[0].setBrightness(this.Brightness);
+          return await device_list[0].setBrightness(this.Brightness);
         })
         .then(() => {
           this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Done.`);
@@ -615,9 +615,9 @@ export class ColorBulb {
           model: 'u',
           id: this.device.bleMac,
         })
-        .then((device_list: any) => {
+        .then(async (device_list: any) => {
           this.infoLog(`${this.accessory.displayName} Target ColorTemperature: ${this.ColorTemperature}`);
-          return device_list[0].setColorTemperature(this.ColorTemperature);
+          return await device_list[0].setColorTemperature(this.ColorTemperature);
         })
         .then(() => {
           this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Done.`);
@@ -657,9 +657,9 @@ export class ColorBulb {
           model: 'u',
           id: this.device.bleMac,
         })
-        .then((device_list: any) => {
+        .then(async (device_list: any) => {
           this.infoLog(`${this.accessory.displayName} Target RGB: ${this.Brightness, red, green, blue}`);
-          return device_list[0].setRGB(this.Brightness, red, green, blue);
+          return await device_list[0].setRGB(this.Brightness, red, green, blue);
         })
         .then(() => {
           this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Done.`);

--- a/src/device/colorbulb.ts
+++ b/src/device/colorbulb.ts
@@ -1123,11 +1123,11 @@ export class ColorBulb {
   }
 
   async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
-    return fn().catch(async (err: any) => {
+    return fn().catch(async (e: any) => {
       if (max === 0) {
-        throw err;
+        throw e;
       }
-      this.infoLog(err);
+      this.infoLog(e);
       this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} Retrying`);
       await sleep(1000);
       return this.retry({ max: max - 1, fn });

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -575,8 +575,8 @@ export class Curtain {
             this.infoLog(`${this.accessory.displayName} Target Position: ${this.TargetPosition}`);
             return await this.retry({
               max: await this.maxRetry(),
-              fn: () => {
-                return device_list[0].runToPos(100 - Number(this.TargetPosition), adjustedMode);
+              fn: async () => {
+                return await device_list[0].runToPos(100 - Number(this.TargetPosition), adjustedMode);
               },
             });
           })

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -601,11 +601,11 @@ export class Curtain {
   }
 
   async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
-    return fn().catch(async (err: any) => {
+    return fn().catch(async (e: any) => {
       if (max === 0) {
-        throw err;
+        throw e;
       }
-      this.infoLog(err);
+      this.infoLog(e);
       this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} Retrying`);
       await sleep(1000);
       return this.retry({ max: max - 1, fn });

--- a/src/device/humidifier.ts
+++ b/src/device/humidifier.ts
@@ -455,9 +455,9 @@ export class Humidifier {
         quick: true,
         id: this.device.bleMac,
       })
-      .then((device_list: any) => {
+      .then(async (device_list: any) => {
         this.infoLog(`${this.accessory.displayName} Target Position: ${this.Active}`);
-        return device_list[0].percentage(this.RelativeHumidityHumidifierThreshold);
+        return await device_list[0].percentage(this.RelativeHumidityHumidifierThreshold);
       })
       .then(() => {
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Done.`);

--- a/src/device/motion.ts
+++ b/src/device/motion.ts
@@ -456,11 +456,11 @@ export class Motion {
   }
 
   async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
-    return fn().catch(async (err: any) => {
+    return fn().catch(async (e: any) => {
       if (max === 0) {
-        throw err;
+        throw e;
       }
-      this.infoLog(err);
+      this.infoLog(e);
       this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} Retrying`);
       await sleep(1000);
       return this.retry({ max: max - 1, fn });

--- a/src/device/plug.ts
+++ b/src/device/plug.ts
@@ -352,11 +352,11 @@ export class Plug {
           this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
           return await this.retry({
             max: await this.maxRetry(),
-            fn: () => {
+            fn: async () => {
               if (this.On) {
-                return device_list[0].turnOn({ id: this.device.bleMac });
+                return await device_list[0].turnOn({ id: this.device.bleMac });
               } else {
-                return device_list[0].turnOff({ id: this.device.bleMac });
+                return await device_list[0].turnOff({ id: this.device.bleMac });
               }
             },
           });

--- a/src/device/plug.ts
+++ b/src/device/plug.ts
@@ -522,11 +522,11 @@ export class Plug {
   }
 
   async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
-    return fn().catch(async (err: any) => {
+    return fn().catch(async (e: any) => {
       if (max === 0) {
-        throw err;
+        throw e;
       }
-      this.infoLog(err);
+      this.infoLog(e);
       this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} Retrying`);
       await sleep(1000);
       return this.retry({ max: max - 1, fn });

--- a/src/device/robotvacuumcleaner.ts
+++ b/src/device/robotvacuumcleaner.ts
@@ -646,11 +646,11 @@ export class RobotVacuumCleaner {
   }
 
   async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
-    return fn().catch(async (err: any) => {
+    return fn().catch(async (e: any) => {
       if (max === 0) {
-        throw err;
+        throw e;
       }
-      this.infoLog(err);
+      this.infoLog(e);
       this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} Retrying`);
       await sleep(1000);
       return this.retry({ max: max - 1, fn });

--- a/src/device/robotvacuumcleaner.ts
+++ b/src/device/robotvacuumcleaner.ts
@@ -363,11 +363,11 @@ export class RobotVacuumCleaner {
           this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
           return await this.retry({
             max: await this.maxRetry(),
-            fn: () => {
+            fn: async () => {
               if (this.On) {
-                return device_list[0].turnOn({ id: this.device.bleMac });
+                return await device_list[0].turnOn({ id: this.device.bleMac });
               } else {
-                return device_list[0].turnOff({ id: this.device.bleMac });
+                return await device_list[0].turnOff({ id: this.device.bleMac });
               }
             },
           });

--- a/src/device/striplight.ts
+++ b/src/device/striplight.ts
@@ -887,11 +887,11 @@ export class StripLight {
   }
 
   async retry({ max, fn }: { max: number; fn: { (): any; (): Promise<any> } }): Promise<null> {
-    return fn().catch(async (err: any) => {
+    return fn().catch(async (e: any) => {
       if (max === 0) {
-        throw err;
+        throw e;
       }
-      this.infoLog(err);
+      this.infoLog(e);
       this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} Retrying`);
       await sleep(1000);
       return this.retry({ max: max - 1, fn });

--- a/src/device/striplight.ts
+++ b/src/device/striplight.ts
@@ -468,11 +468,11 @@ export class StripLight {
           this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} On: ${this.On}`);
           return await this.retry({
             max: await this.maxRetry(),
-            fn: () => {
+            fn: async () => {
               if (this.On) {
-                return device_list[0].turnOn({ id: this.device.bleMac });
+                return await device_list[0].turnOn({ id: this.device.bleMac });
               } else {
-                return device_list[0].turnOff({ id: this.device.bleMac });
+                return await device_list[0].turnOff({ id: this.device.bleMac });
               }
             },
           });
@@ -516,9 +516,9 @@ export class StripLight {
           model: 'u',
           id: this.device.bleMac,
         })
-        .then((device_list: any) => {
+        .then(async (device_list: any) => {
           this.infoLog(`${this.accessory.displayName} Target Brightness: ${this.Brightness}`);
-          return device_list[0].setBrightness(this.Brightness);
+          return await device_list[0].setBrightness(this.Brightness);
         })
         .then(() => {
           this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Done.`);
@@ -557,9 +557,9 @@ export class StripLight {
           model: 'u',
           id: this.device.bleMac,
         })
-        .then((device_list: any) => {
+        .then(async (device_list: any) => {
           this.infoLog(`${this.accessory.displayName} Target RGB: ${this.Brightness, red, green, blue}`);
-          return device_list[0].setRGB(this.Brightness, red, green, blue);
+          return await device_list[0].setRGB(this.Brightness, red, green, blue);
         })
         .then(() => {
           this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Done.`);


### PR DESCRIPTION
## :recycle: Current situation

The `node-switchbot` package can return a promise rejection [here](https://github.com/OpenWonderLabs/node-switchbot/blob/c38eba8/lib/switchbot-device-wocurtain.js#L91) that is not handled.

This can result in an error message being parsed as device data. As a consequence, the following error message can occur:
```
[@switchbot/homebridge-switchbot] This plugin generated a warning from the characteristic 'Battery Level': characteristic value expected valid finite number and received "NaN" (number). See https://homebridge.io/w/JtMGR for more info.
```

## :bulb: Proposed solution

Catch the rejection.

## :heavy_plus_sign: Additional Information
This change was made earlier for the curtain in https://github.com/OpenWonderLabs/homebridge-switchbot/pull/657, it seems to have only been merged into a beta branch though.