### PR TITLE
Ability to use temperature and humidity data from another switchbot device for AC #389

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -990,6 +990,52 @@
                       "condition": {
                         "functionBody": "return (model.options && model.options.irdevices && !model.options.irdevices[arrayIndices].hide_device && (model.options.irdevices[arrayIndices].configRemoteType === 'Air Conditioner' || model.options.irdevices[arrayIndices].configRemoteType === 'DIY Air Conditioner') && model.options.irdevices[arrayIndices].deviceId);"
                       }
+                    },
+                    "meterType": {
+                      "title": "Use an existing Switchbot device for temperature/humidity",
+                      "type": "string",
+                      "oneOf": [
+                        {
+                          "title": "Meter",
+                          "enum": [
+                            "Meter"
+                          ]
+                        },
+                        {
+                          "title": "MeterPlus",
+                          "enum": [
+                            "MeterPlus"
+                          ]
+                        },
+                        {
+                          "title": "Meter Plus (JP)",
+                          "enum": [
+                            "Meter Plus (JP)"
+                          ]
+                        },
+                        {
+                          "title": "Hub 2",
+                          "enum": [
+                            "Hub 2"
+                          ]
+                        },
+                        {
+                          "title": "WoIOSensor",
+                          "enum": [
+                            "WoIOSensor"
+                          ]
+                        }
+                      ],
+                      "condition": {
+                        "functionBody": "return (model.options && model.options.irdevices && !model.options.irdevices[arrayIndices].hide_device && (model.options.irdevices[arrayIndices].configRemoteType === 'Air Conditioner' || model.options.irdevices[arrayIndices].configRemoteType === 'DIY Air Conditioner') && model.options.irdevices[arrayIndices].deviceId);"
+                      }
+                    },
+                    "meterId": {
+                      "title": "Device ID of the device to use for temperature/humidity",
+                      "type": "string",
+                      "condition": {
+                        "functionBody": "return (model.options && model.options.irdevices && !model.options.irdevices[arrayIndices].hide_device && (model.options.irdevices[arrayIndices].configRemoteType === 'Air Conditioner' || model.options.irdevices[arrayIndices].configRemoteType === 'DIY Air Conditioner') && model.options.irdevices[arrayIndices].deviceId && model.options.irdevices[arrayIndices].irair?.meterType);"
+                      }
                     }
                   }
                 },
@@ -1241,6 +1287,8 @@
             "options.irdevices[].disablePushOff",
             "options.irdevices[].disablePushDetail",
             "options.irdevices[].irair.hide_automode",
+            "options.irdevices[].irair.meterType",
+            "options.irdevices[].irair.meterId",
             "options.irdevices[].irfan.rotation_speed",
             "options.irdevices[].irfan.swing_mode",
             "options.irdevices[].irfan.set_minStep",

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -1635,13 +1635,16 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
     }
   }
 
-  private async createAirConditioner(device: irdevice & devicesConfig) {
+  private async createAirConditioner(device: irdevice & devicesConfig & irDevicesConfig) {
     const uuid = this.api.hap.uuid.generate(`${device.deviceId}-${device.remoteType}`);
 
     // see if an accessory with the same uuid has already been registered and restored from
     // the cached devices we stored in the `configureAccessory` method above
     const existingAccessory = this.accessories.find((accessory) => accessory.UUID === uuid);
 
+    if (device.irair?.meterType && device.irair?.meterId) {
+      device.irair.meterUuid = this.api.hap.uuid.generate(`${device.irair.meterId}-${device.irair.meterType}`);
+    }
     if (existingAccessory) {
       // the accessory already exists
       if (!device.hide_device && device.hubDeviceId) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -188,6 +188,9 @@ export type irfan = {
 
 export type irair = {
   hide_automode?: boolean;
+  meterType?: string;
+  meterId?: string;
+  meterUuid?: string;
 };
 
 export type other = {


### PR DESCRIPTION
## :recycle: Current situation

The current implementation of IR air conditioners uses a default temperature, resulting in inaccurate climate conditions in homekit.

## :bulb: Proposed solution

Use an existing switchbot device with temperature and humidity data as the data source for the AC temperature and humidity.

## :gear: Release Notes

This PR allows the user to select an existing switchbot device for temperature and humidity data for an AC device.

Adds optional `meterType` and `meterId` config options to select the relevant device to use for temperature and humidity for the AC device.  

If no options are provided or the specified device is not found, the functionality will remain unchanged.

## :heavy_plus_sign: Additional Information

Have only tested with a regular switchbot meter, but should theoretically work with other switchbot devices that support temp/humidity like the hub 2 and WoIOSensor.