### PR TITLE
EVE history view for curtain device.

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,9 @@
     "@homebridge/plugin-ui-utils": "^0.0.19",
     "async-mqtt": "^2.6.3",
     "crypto-js": "^4.1.1",
-    "fakegato-history": "^0.6.3",
+    "fakegato-history": "^0.6.4",
     "node-switchbot": "1.8.1",
+    "homebridge-lib": "^6.3.18",
     "rxjs": "^7.8.0",
     "undici": "^5.21.2"
   },

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -6,8 +6,9 @@ import { interval, Subject } from 'rxjs';
 import { connectAsync } from 'async-mqtt';
 import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
+import { Service, PlatformAccessory, CharacteristicValue, CharacteristicChange } from 'homebridge';
 import { device, devicesConfig, serviceData, switchbot, deviceStatus, ad, Devices } from '../settings';
+import { hostname } from 'os';
 
 export class Curtain {
   // Services
@@ -22,6 +23,7 @@ export class Curtain {
   CurrentAmbientLightLevel?: CharacteristicValue;
   BatteryLevel?: CharacteristicValue;
   StatusLowBattery?: CharacteristicValue;
+  lastActivation?: number;
 
   // OpenAPI Others
   deviceStatus!: any; //deviceStatusResponse;
@@ -68,6 +70,9 @@ export class Curtain {
   // Connection
   private readonly BLE = (this.device.connectionType === 'BLE' || this.device.connectionType === 'BLE/OpenAPI');
   private readonly OpenAPI = (this.device.connectionType === 'OpenAPI' || this.device.connectionType === 'BLE/OpenAPI');
+
+  // EVE history service handler
+  historyService: any = null;
 
   constructor(private readonly platform: SwitchBotPlatform, private accessory: PlatformAccessory, public device: device & devicesConfig) {
     // default placeholders
@@ -218,8 +223,72 @@ export class Curtain {
         }
         this.curtainUpdateInProgress = false;
       });
+
+    // Setup EVE history features
+    this.setupHistoryService(device);
   }
 
+  /*
+   * Setup EVE history features for curtain devices. 
+   */
+  async setupHistoryService(device: device & devicesConfig): Promise<void> {
+    if (device.history !== true) {
+      return;
+    }
+    
+    const mac = this.device
+      .deviceId!.match(/.{1,2}/g)!
+      .join(':')
+      .toLowerCase();
+    this.historyService =
+      new this.platform.fakegatoAPI('custom', this.accessory, {
+	log: this.platform.log,
+	storage: 'fs',
+	filename: `${hostname().split(".")[0]}_${mac}_persist.json`
+      });
+    const motion: Service =
+	  this.accessory.getService(this.platform.Service.MotionSensor) ||
+	  this.accessory.addService(this.platform.Service.MotionSensor,
+				    `${this.accessory.displayName} Motion`);
+    motion.addOptionalCharacteristic(this.platform.eve.Characteristics.LastActivation);
+    motion.getCharacteristic(this.platform.eve.Characteristics.LastActivation)
+      .onGet(() => {
+	const lastActivation = this.accessory.context.lastActivation ?
+	      Math.max(0, this.accessory.context.lastActivation -
+		       this.historyService.getInitialTime()) : 0;
+	return lastActivation;
+      });
+    await this.setMinMax();
+    motion.getCharacteristic(this.platform.Characteristic.MotionDetected)
+      .on('change', (event: CharacteristicChange) => {
+	if (event.newValue !== event.oldValue) {
+	  const sensor = this.accessory.getService(this.platform.Service.MotionSensor);
+          const entry = {
+            time: Math.round(new Date().valueOf()/1000),
+            motion: event.newValue
+          };
+          this.accessory.context.lastActivation = entry.time;
+          sensor?.updateCharacteristic(
+	    this.platform.eve.Characteristics.LastActivation,
+	    Math.max(0, this.accessory.context.lastActivation -
+		     this.historyService.getInitialTime()));
+          this.historyService.addEntry(entry);
+	}
+      });
+    this.updateHistory();
+  }
+
+  async updateHistory() : Promise<void>{
+    const motion = Number(this.CurrentPosition) > 0 ? 1 : 0;
+    this.historyService.addEntry ({
+      time: Math.round(new Date().valueOf()/1000),
+      motion: motion
+    });
+    setTimeout(() => {
+      this.updateHistory();
+    }, 10 * 60 * 1000);
+  }
+  
   /**
    * Parse the device status from the SwitchBot api
    */
@@ -724,6 +793,12 @@ export class Curtain {
         this.lightSensorService?.updateCharacteristic(this.platform.Characteristic.CurrentAmbientLightLevel, this.CurrentAmbientLightLevel);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName}`
           + ` updateCharacteristic CurrentAmbientLightLevel: ${this.CurrentAmbientLightLevel}`);
+	if (this.device.history) {
+	  this.historyService?.addEntry ({
+	    time: Math.round(new Date().valueOf()/1000),
+	    lux: this.CurrentAmbientLightLevel
+	  });
+	}
       }
     }
     if (this.BLE) {
@@ -856,6 +931,11 @@ export class Curtain {
         this.CurrentPosition = 100;
       }
     }
+    if (this.device.history) {
+      const motion = this.accessory.getService(this.platform.Service.MotionSensor);
+      const state = Number(this.CurrentPosition) > 0 ? 1 : 0;
+      motion?.updateCharacteristic(this.platform.Characteristic.MotionDetected, state);
+    }
   }
 
   minStep(device: device & devicesConfig): number {
@@ -987,22 +1067,49 @@ export class Curtain {
   }
 
   async context() {
-    if (this.CurrentPosition === undefined) {
+    if (this.accessory.context.CurrentPosition === undefined) {
       this.CurrentPosition = 0;
     } else {
       this.CurrentPosition = this.accessory.context.CurrentPosition;
     }
 
-    if (this.TargetPosition === undefined) {
+    if (this.accessory.context.TargetPosition === undefined) {
       this.TargetPosition = 0;
     } else {
       this.TargetPosition = this.accessory.context.TargetPosition;
     }
 
-    if (this.PositionState === undefined) {
+    if (this.accessory.context.PositionState === undefined) {
       this.PositionState = this.platform.Characteristic.PositionState.STOPPED;
     } else {
       this.PositionState = this.accessory.context.PositionState;
+    }
+
+    if (!this.device.curtain?.hide_lightsensor) {
+      if (this.accessory.context.CurrentAmbientLightLevel !== undefined) {
+	this.CurrentAmbientLightLevel = this.accessory.context.CurrentAmbientLightLevel;
+      }
+    }
+
+    if (this.BLE) {
+      if (this.accessory.context.BatteryLevel === undefined) {
+	this.BatteryLevel = 100;
+      } else {
+	this.BatteryLevel = this.accessory.context.BatteryLevel;
+      }
+      if (this.accessory.context.StatusLowBattery === undefined) {
+	this.StatusLowBattery = this.platform.Characteristic.StatusLowBattery.BATTERY_LEVEL_NORMAL;
+      } else {
+	this.StatusLowBattery = this.accessory.context.StatusLowBattery;
+      }
+    }
+    
+    if (this.device.history === true) {
+      // initialize when this accessory is newly created.
+      this.accessory.context.lastActivation = this.accessory.context.lastActivation ?? 0;
+    } else {
+      // removes cached values if history is turned off
+      delete this.accessory.context.lastActivation;
     }
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -28,6 +28,7 @@ import crypto, { randomUUID } from 'crypto';
 import { Buffer } from 'buffer';
 import { queueScheduler } from 'rxjs';
 import fakegato from 'fakegato-history';
+import { EveHomeKitTypes } from 'homebridge-lib';
 
 import { readFileSync, writeFileSync } from 'fs';
 import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, Service, Characteristic } from 'homebridge';
@@ -51,6 +52,7 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
   platformLogging?: string;
 
   public readonly fakegatoAPI: any;
+  public readonly eve: any;
 
   constructor(public readonly log: Logger, public readonly config: SwitchBotPlatformConfig, public readonly api: API) {
     this.logs();
@@ -76,8 +78,9 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
       return;
     }
 
-    // import fakegato-history module
+    // import fakegato-history module and EVE characteristics
     this.fakegatoAPI = fakegato(api);
+    this.eve = new EveHomeKitTypes(api);
 
     // When this event is fired it means Homebridge has restored all cached accessories from disk.
     // Dynamic Platform plugins should only register new accessories after this event was fired,


### PR DESCRIPTION
## :bulb: Proposed solution

This PR enables EVE app history views for curtain device including open/close and light-level.

## :gear: Release Notes

To enable EVE history view, as well as meter devices, add '"history": true' in a config.json for target curtain devices.

 "devices": [{
 "deviceId": "XXXXXXXXXXXX",
 ...
 **"history": true**
},

## :heavy_plus_sign: Additional Information

EVE shows ''No data available" for light-level view, if same values are kept more than few hours (8H I guess from my expirence). The view shows the history again after the light-level is varied. 

This function requires latest fakegato-history library of 0.6.4.

To @donavanbecker,

To inherit characteristics of last execution at restarting, I revised the function context() in src/device/curtain.ts. I hope you will check the code. If my revision is out of your design intention, I will revert my revision. 
