### PR TITLE
Throw error on unknown status code from API 

### DIFF
--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -535,8 +535,9 @@ export class BlindTilt {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -681,8 +682,9 @@ export class BlindTilt {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -1037,6 +1039,7 @@ export class BlindTilt {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -1050,7 +1053,7 @@ export class BlindTilt {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -1,13 +1,13 @@
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { MqttClient } from 'mqtt';
-import { interval, Subject } from 'rxjs';
 import { connectAsync } from 'async-mqtt';
-import { SwitchBotPlatform } from '../platform';
+import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { MqttClient } from 'mqtt';
+import { Subject, interval } from 'rxjs';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { device, devicesConfig, serviceData, switchbot, deviceStatus, ad, Devices } from '../settings';
+import { request } from 'undici';
+import { Context } from 'vm';
+import { SwitchBotPlatform } from '../platform';
+import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 enum BlindTiltMappingMode {
   OnlyUp = 'only_up',
@@ -535,9 +535,9 @@ export class BlindTilt {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.slidePosition = deviceStatus.body.slidePosition;
@@ -681,9 +681,9 @@ export class BlindTilt {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -1072,6 +1072,7 @@ export class BlindTilt {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -7,7 +7,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 enum BlindTiltMappingMode {
   OnlyUp = 'only_up',
@@ -1033,46 +1033,24 @@ export class BlindTilt {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -1,11 +1,11 @@
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { interval, Subject } from 'rxjs';
-import { SwitchBotPlatform } from '../platform';
+import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { Subject, interval } from 'rxjs';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { device, devicesConfig, deviceStatus, ad, serviceData, switchbot, Devices } from '../settings';
+import { request } from 'undici';
+import { Context } from 'vm';
+import { SwitchBotPlatform } from '../platform';
+import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -563,20 +563,18 @@ export class Bot {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      if (statusCode === 200) {
-        const deviceStatus: any = await body.json();
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
-        this.power = deviceStatus.body.power;
-        this.Battery = deviceStatus.body.battery;
-        this.Version = deviceStatus.body.version;
-        this.openAPIparseStatus();
-        this.updateHomeKitCharacteristics();
-      } else {
-        this.statusCode(statusCode);
-      }
+
+      this.statusCode(statusCode);
+      const deviceStatus: any = await body.json();
+      this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
+      this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
+      this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
+      this.power = deviceStatus.body.power;
+      this.Battery = deviceStatus.body.battery;
+      this.Version = deviceStatus.body.version;
+      this.openAPIparseStatus();
+      this.updateHomeKitCharacteristics();
+
     } catch (e: any) {
       this.apiError(e);
       this.errorLog(
@@ -729,9 +727,9 @@ export class Bot {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         if (this.device.bot?.mode === 'multipress') {
           this.multiPressCount--;
@@ -1263,6 +1261,7 @@ export class Bot {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -5,7 +5,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -563,7 +563,6 @@ export class Bot {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-
       this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
@@ -1222,46 +1221,25 @@ export class Bot {
     }
   }
 
+
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -563,8 +563,9 @@ export class Bot {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -726,8 +727,9 @@ export class Bot {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         if (this.device.bot?.mode === 'multipress') {
@@ -1226,6 +1228,7 @@ export class Bot {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -1239,7 +1242,7 @@ export class Bot {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/ceilinglight.ts
+++ b/src/device/ceilinglight.ts
@@ -6,7 +6,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, hs2rgb, m2hs, rgb2hs, serviceData, switchbot } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -528,9 +528,9 @@ export class CeilingLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -579,9 +579,9 @@ export class CeilingLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -615,9 +615,9 @@ export class CeilingLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -901,46 +901,24 @@ export class CeilingLight {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/ceilinglight.ts
+++ b/src/device/ceilinglight.ts
@@ -1,12 +1,12 @@
 /* eslint-disable brace-style */
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { interval, Subject } from 'rxjs';
-import { SwitchBotPlatform } from '../platform';
+import { CharacteristicValue, Controller, ControllerConstructor, ControllerServiceMap, PlatformAccessory, Service } from 'homebridge';
+import { Subject, interval } from 'rxjs';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { device, devicesConfig, deviceStatus, switchbot, hs2rgb, rgb2hs, m2hs, serviceData, ad, Devices } from '../settings';
-import { Service, PlatformAccessory, CharacteristicValue, ControllerConstructor, Controller, ControllerServiceMap } from 'homebridge';
+import { request } from 'undici';
+import { Context } from 'vm';
+import { SwitchBotPlatform } from '../platform';
+import { Devices, ad, device, deviceStatus, devicesConfig, hs2rgb, m2hs, rgb2hs, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -406,9 +406,9 @@ export class CeilingLight {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.power = deviceStatus.body.power;
@@ -649,9 +649,9 @@ export class CeilingLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -940,6 +940,7 @@ export class CeilingLight {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/ceilinglight.ts
+++ b/src/device/ceilinglight.ts
@@ -406,8 +406,9 @@ export class CeilingLight {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -528,8 +529,9 @@ export class CeilingLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -579,8 +581,9 @@ export class CeilingLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -615,8 +618,9 @@ export class CeilingLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -649,8 +653,9 @@ export class CeilingLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -905,6 +910,7 @@ export class CeilingLight {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -918,7 +924,7 @@ export class CeilingLight {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/colorbulb.ts
+++ b/src/device/colorbulb.ts
@@ -6,7 +6,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, hs2rgb, m2hs, rgb2hs, serviceData, switchbot } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -1072,46 +1072,24 @@ export class ColorBulb {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/colorbulb.ts
+++ b/src/device/colorbulb.ts
@@ -441,8 +441,9 @@ export class ColorBulb {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -699,8 +700,9 @@ export class ColorBulb {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -750,8 +752,9 @@ export class ColorBulb {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -786,8 +789,9 @@ export class ColorBulb {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -820,8 +824,9 @@ export class ColorBulb {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -1076,6 +1081,7 @@ export class ColorBulb {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -1089,7 +1095,7 @@ export class ColorBulb {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/colorbulb.ts
+++ b/src/device/colorbulb.ts
@@ -1,12 +1,12 @@
 /* eslint-disable brace-style */
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { interval, Subject } from 'rxjs';
-import { SwitchBotPlatform } from '../platform';
+import { CharacteristicValue, Controller, ControllerConstructor, ControllerServiceMap, PlatformAccessory, Service } from 'homebridge';
+import { Subject, interval } from 'rxjs';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { device, devicesConfig, deviceStatus, switchbot, hs2rgb, rgb2hs, m2hs, serviceData, ad, Devices } from '../settings';
-import { Service, PlatformAccessory, CharacteristicValue, ControllerConstructor, Controller, ControllerServiceMap } from 'homebridge';
+import { request } from 'undici';
+import { Context } from 'vm';
+import { SwitchBotPlatform } from '../platform';
+import { Devices, ad, device, deviceStatus, devicesConfig, hs2rgb, m2hs, rgb2hs, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -441,9 +441,9 @@ export class ColorBulb {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.power = deviceStatus.body.power;
@@ -699,9 +699,9 @@ export class ColorBulb {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -750,9 +750,9 @@ export class ColorBulb {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -786,9 +786,9 @@ export class ColorBulb {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -820,9 +820,9 @@ export class ColorBulb {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -1111,6 +1111,7 @@ export class ColorBulb {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/contact.ts
+++ b/src/device/contact.ts
@@ -400,8 +400,9 @@ export class Contact {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -541,6 +542,7 @@ export class Contact {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -554,7 +556,7 @@ export class Contact {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/contact.ts
+++ b/src/device/contact.ts
@@ -1,11 +1,11 @@
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { interval, Subject } from 'rxjs';
+import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { Subject, interval } from 'rxjs';
 import { skipWhile } from 'rxjs/operators';
+import { request } from 'undici';
+import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
-import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { device, devicesConfig, serviceData, switchbot, deviceStatus, ad, Devices } from '../settings';
+import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -400,9 +400,9 @@ export class Contact {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.openState = deviceStatus.body.openState;
@@ -576,6 +576,7 @@ export class Contact {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/contact.ts
+++ b/src/device/contact.ts
@@ -5,7 +5,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -537,46 +537,24 @@ export class Contact {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -8,7 +8,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 export class Curtain {
   // Services
@@ -1014,46 +1014,24 @@ export class Curtain {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -1,14 +1,14 @@
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { MqttClient } from 'mqtt';
-import { interval, Subject } from 'rxjs';
 import { connectAsync } from 'async-mqtt';
-import { SwitchBotPlatform } from '../platform';
-import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { Service, PlatformAccessory, CharacteristicValue, CharacteristicChange } from 'homebridge';
-import { device, devicesConfig, serviceData, switchbot, deviceStatus, ad, Devices } from '../settings';
+import { CharacteristicChange, CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { MqttClient } from 'mqtt';
 import { hostname } from 'os';
+import { Subject, interval } from 'rxjs';
+import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
+import { request } from 'undici';
+import { Context } from 'vm';
+import { SwitchBotPlatform } from '../platform';
+import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 export class Curtain {
   // Services
@@ -559,9 +559,9 @@ export class Curtain {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.slidePosition = deviceStatus.body.slidePosition;
@@ -705,9 +705,9 @@ export class Curtain {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -1053,6 +1053,7 @@ export class Curtain {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -559,8 +559,9 @@ export class Curtain {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -705,8 +706,9 @@ export class Curtain {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -1018,6 +1020,7 @@ export class Curtain {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -1031,7 +1034,7 @@ export class Curtain {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/hub.ts
+++ b/src/device/hub.ts
@@ -294,8 +294,9 @@ export class Hub {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -370,6 +371,7 @@ export class Hub {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -383,7 +385,7 @@ export class Hub {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/hub.ts
+++ b/src/device/hub.ts
@@ -4,7 +4,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, device, deviceStatus, devicesConfig } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 export class Hub {
   // Services
@@ -366,46 +366,24 @@ export class Hub {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/hub.ts
+++ b/src/device/hub.ts
@@ -294,9 +294,9 @@ export class Hub {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.CurrentTemperature = deviceStatus.body.temperature;
@@ -405,6 +405,7 @@ export class Hub {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/humidifier.ts
+++ b/src/device/humidifier.ts
@@ -1,12 +1,12 @@
 /* eslint-disable brace-style */
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { interval, Subject } from 'rxjs';
-import { SwitchBotPlatform } from '../platform';
+import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { Subject, interval } from 'rxjs';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { device, devicesConfig, serviceData, ad, deviceStatus, Devices } from '../settings';
+import { request } from 'undici';
+import { Context } from 'vm';
+import { SwitchBotPlatform } from '../platform';
+import { Devices, ad, device, deviceStatus, devicesConfig, serviceData } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -379,9 +379,9 @@ export class Humidifier {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.auto = deviceStatus.body.auto;
@@ -475,9 +475,9 @@ export class Humidifier {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -518,9 +518,9 @@ export class Humidifier {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -556,9 +556,9 @@ export class Humidifier {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -810,6 +810,7 @@ export class Humidifier {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/humidifier.ts
+++ b/src/device/humidifier.ts
@@ -6,7 +6,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -771,46 +771,24 @@ export class Humidifier {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/humidifier.ts
+++ b/src/device/humidifier.ts
@@ -379,8 +379,9 @@ export class Humidifier {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -475,8 +476,9 @@ export class Humidifier {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -518,8 +520,9 @@ export class Humidifier {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -556,8 +559,9 @@ export class Humidifier {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -775,6 +779,7 @@ export class Humidifier {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -788,7 +793,7 @@ export class Humidifier {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/iosensor.ts
+++ b/src/device/iosensor.ts
@@ -1,14 +1,14 @@
-import { Context } from 'vm';
-import { hostname } from 'os';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { MqttClient } from 'mqtt';
 import { connectAsync } from 'async-mqtt';
-import { interval, Subject } from 'rxjs';
+import { CharacteristicValue, PlatformAccessory, Service, Units } from 'homebridge';
+import { MqttClient } from 'mqtt';
+import { hostname } from 'os';
+import { Subject, interval } from 'rxjs';
 import { skipWhile } from 'rxjs/operators';
+import { request } from 'undici';
+import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
-import { Service, PlatformAccessory, Units, CharacteristicValue } from 'homebridge';
-import { device, devicesConfig, serviceData, ad, switchbot, temperature, deviceStatus, Devices } from '../settings';
+import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot, temperature } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -338,9 +338,9 @@ export class IOSensor {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.Humidity = deviceStatus.body.humidity!;
@@ -566,6 +566,7 @@ export class IOSensor {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/iosensor.ts
+++ b/src/device/iosensor.ts
@@ -338,8 +338,9 @@ export class IOSensor {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -531,6 +532,7 @@ export class IOSensor {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -544,7 +546,7 @@ export class IOSensor {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/iosensor.ts
+++ b/src/device/iosensor.ts
@@ -8,7 +8,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot, temperature } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -527,46 +527,24 @@ export class IOSensor {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/lightstrip.ts
+++ b/src/device/lightstrip.ts
@@ -381,8 +381,9 @@ export class StripLight {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -594,8 +595,9 @@ export class StripLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -642,8 +644,9 @@ export class StripLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -676,8 +679,9 @@ export class StripLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -932,6 +936,7 @@ export class StripLight {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -945,7 +950,7 @@ export class StripLight {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/lightstrip.ts
+++ b/src/device/lightstrip.ts
@@ -1,12 +1,12 @@
 /* eslint-disable brace-style */
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
+import { CharacteristicValue, Controller, ControllerConstructor, ControllerServiceMap, PlatformAccessory, Service } from 'homebridge';
 import { interval, Subject } from 'rxjs';
-import { SwitchBotPlatform } from '../platform';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { Service, PlatformAccessory, CharacteristicValue, ControllerConstructor, Controller, ControllerServiceMap } from 'homebridge';
-import { device, devicesConfig, switchbot, hs2rgb, rgb2hs, deviceStatus, ad, serviceData, m2hs, Devices } from '../settings';
+import { request } from 'undici';
+import { Context } from 'vm';
+import { SwitchBotPlatform } from '../platform';
+import { ad, device, Devices, devicesConfig, deviceStatus, hs2rgb, m2hs, rgb2hs, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -381,9 +381,9 @@ export class StripLight {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.power = deviceStatus.body.power;
@@ -594,9 +594,9 @@ export class StripLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -642,9 +642,9 @@ export class StripLight {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -967,6 +967,7 @@ export class StripLight {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/lock.ts
+++ b/src/device/lock.ts
@@ -312,8 +312,9 @@ export class Lock {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -421,8 +422,9 @@ export class Lock {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -542,6 +544,7 @@ export class Lock {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -555,7 +558,7 @@ export class Lock {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/lock.ts
+++ b/src/device/lock.ts
@@ -6,7 +6,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 export class Lock {
   // Services
@@ -538,46 +538,24 @@ export class Lock {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/lock.ts
+++ b/src/device/lock.ts
@@ -1,12 +1,12 @@
 /* eslint-disable brace-style */
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { interval, Subject } from 'rxjs';
-import { SwitchBotPlatform } from '../platform';
+import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { Subject, interval } from 'rxjs';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { device, devicesConfig, deviceStatus, switchbot, ad, serviceData, Devices } from '../settings';
+import { request } from 'undici';
+import { Context } from 'vm';
+import { SwitchBotPlatform } from '../platform';
+import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 export class Lock {
   // Services
@@ -312,9 +312,9 @@ export class Lock {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.lockState = deviceStatus.body.lockState;
@@ -421,9 +421,9 @@ export class Lock {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -577,6 +577,7 @@ export class Lock {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/meter.ts
+++ b/src/device/meter.ts
@@ -344,8 +344,9 @@ export class Meter {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -539,6 +540,7 @@ export class Meter {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -552,7 +554,7 @@ export class Meter {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/meter.ts
+++ b/src/device/meter.ts
@@ -8,7 +8,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot, temperature } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -535,46 +535,24 @@ export class Meter {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/meter.ts
+++ b/src/device/meter.ts
@@ -344,9 +344,9 @@ export class Meter {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.Humidity = deviceStatus.body.humidity!;
@@ -574,6 +574,7 @@ export class Meter {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/meterplus.ts
+++ b/src/device/meterplus.ts
@@ -344,8 +344,9 @@ export class MeterPlus {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -550,6 +551,7 @@ export class MeterPlus {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -563,7 +565,7 @@ export class MeterPlus {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/meterplus.ts
+++ b/src/device/meterplus.ts
@@ -8,7 +8,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot, temperature } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -546,46 +546,24 @@ export class MeterPlus {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/meterplus.ts
+++ b/src/device/meterplus.ts
@@ -344,9 +344,9 @@ export class MeterPlus {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.Humidity = deviceStatus.body.humidity!;
@@ -585,6 +585,7 @@ export class MeterPlus {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/motion.ts
+++ b/src/device/motion.ts
@@ -357,8 +357,9 @@ export class Motion {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -508,6 +509,7 @@ export class Motion {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -521,7 +523,7 @@ export class Motion {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/motion.ts
+++ b/src/device/motion.ts
@@ -1,11 +1,11 @@
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
+import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import { interval, Subject } from 'rxjs';
 import { skipWhile } from 'rxjs/operators';
+import { request } from 'undici';
+import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
-import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { device, devicesConfig, serviceData, switchbot, deviceStatus, ad, Devices } from '../settings';
+import { ad, device, Devices, devicesConfig, deviceStatus, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -357,9 +357,9 @@ export class Motion {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.moveDetected = deviceStatus.body.moveDetected;
@@ -543,6 +543,7 @@ export class Motion {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/motion.ts
+++ b/src/device/motion.ts
@@ -1,11 +1,11 @@
 import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
-import { interval, Subject } from 'rxjs';
+import { Subject, interval } from 'rxjs';
 import { skipWhile } from 'rxjs/operators';
 import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
-import { ad, device, Devices, devicesConfig, deviceStatus, serviceData, switchbot } from '../settings';
-import { sleep } from '../utils';
+import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
+import { StatusCodeDescription, sleep } from '../utils';
 
 /**
  * Platform Accessory
@@ -504,46 +504,24 @@ export class Motion {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/plug.ts
+++ b/src/device/plug.ts
@@ -5,7 +5,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 export class Plug {
   // Services
@@ -524,46 +524,24 @@ export class Plug {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/plug.ts
+++ b/src/device/plug.ts
@@ -265,8 +265,9 @@ export class Plug {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -383,8 +384,9 @@ export class Plug {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -528,6 +530,7 @@ export class Plug {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -541,7 +544,7 @@ export class Plug {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/plug.ts
+++ b/src/device/plug.ts
@@ -1,11 +1,11 @@
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { interval, Subject } from 'rxjs';
-import { SwitchBotPlatform } from '../platform';
+import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { Subject, interval } from 'rxjs';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { device, devicesConfig, deviceStatus, ad, serviceData, switchbot, Devices } from '../settings';
+import { request } from 'undici';
+import { Context } from 'vm';
+import { SwitchBotPlatform } from '../platform';
+import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 export class Plug {
   // Services
@@ -265,9 +265,9 @@ export class Plug {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.power = deviceStatus.body.power;
@@ -383,9 +383,9 @@ export class Plug {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -563,6 +563,7 @@ export class Plug {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/robotvacuumcleaner.ts
+++ b/src/device/robotvacuumcleaner.ts
@@ -303,8 +303,9 @@ export class RobotVacuumCleaner {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
@@ -422,8 +423,9 @@ export class RobotVacuumCleaner {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
@@ -451,8 +453,9 @@ export class RobotVacuumCleaner {
         method: 'POST',
         headers: this.platform.generateHeaders(),
       });
-      this.statusCode(statusCode);
+      await this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
+      await this.statusCode(deviceStatus.statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
     } catch (e: any) {
@@ -671,6 +674,7 @@ export class RobotVacuumCleaner {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -684,7 +688,7 @@ export class RobotVacuumCleaner {
         this.offlineOff();
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/device/robotvacuumcleaner.ts
+++ b/src/device/robotvacuumcleaner.ts
@@ -6,7 +6,7 @@ import { request } from 'undici';
 import { Context } from 'vm';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
-import { sleep } from '../utils';
+import { StatusCodeDescription, sleep } from '../utils';
 
 export class RobotVacuumCleaner {
   // Services
@@ -667,46 +667,24 @@ export class RobotVacuumCleaner {
     }
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
+    let statusMsg = `${this.device.deviceType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 161 || statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
         this.offlineOff();
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        this.offlineOff();
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/device/robotvacuumcleaner.ts
+++ b/src/device/robotvacuumcleaner.ts
@@ -1,12 +1,12 @@
 /* eslint-disable brace-style */
-import { Context } from 'vm';
-import { request } from 'undici';
-import { sleep } from '../utils';
-import { interval, Subject } from 'rxjs';
-import { SwitchBotPlatform } from '../platform';
+import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
+import { Subject, interval } from 'rxjs';
 import { debounceTime, skipWhile, take, tap } from 'rxjs/operators';
-import { Service, PlatformAccessory, CharacteristicValue } from 'homebridge';
-import { device, devicesConfig, deviceStatus, ad, serviceData, switchbot, Devices } from '../settings';
+import { request } from 'undici';
+import { Context } from 'vm';
+import { SwitchBotPlatform } from '../platform';
+import { Devices, ad, device, deviceStatus, devicesConfig, serviceData, switchbot } from '../settings';
+import { sleep } from '../utils';
 
 export class RobotVacuumCleaner {
   // Services
@@ -303,9 +303,9 @@ export class RobotVacuumCleaner {
       const { body, statusCode, headers } = await request(`${Devices}/${this.device.deviceId}/status`, {
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} refreshStatus: ${JSON.stringify(deviceStatus)}`);
       this.power = deviceStatus.body.power;
@@ -422,9 +422,9 @@ export class RobotVacuumCleaner {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
       } catch (e: any) {
         this.apiError(e);
@@ -451,9 +451,9 @@ export class RobotVacuumCleaner {
         method: 'POST',
         headers: this.platform.generateHeaders(),
       });
+      this.statusCode(statusCode);
       const deviceStatus: any = await body.json();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-      this.statusCode(statusCode);
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
     } catch (e: any) {
       this.apiError(e);
@@ -706,6 +706,7 @@ export class RobotVacuumCleaner {
           `${this.device.deviceType}: ${this.accessory.displayName} Unknown statusCode: ` +
           `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
         );
+        throw new Error(`Unknown Status Code: ${statusCode}`);
     }
   }
 

--- a/src/irdevice/airconditioner.ts
+++ b/src/irdevice/airconditioner.ts
@@ -263,8 +263,9 @@ export class AirConditioner {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
@@ -562,10 +563,11 @@ export class AirConditioner {
   /**
    * Logs the status code and throws an error if the status code is invalid.
    *
-   * @param statusCode - The status code to be validated.
+   * @param APIstatusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
-  async statusCode(statusCode: number): Promise<void> {
+  async statusCode(statusCode:number ): Promise<void> {
     let statusMsg = `${this.device.remoteType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
 
     if (statusCode === 100 || statusCode === 200) {
@@ -575,7 +577,7 @@ export class AirConditioner {
         statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/irdevice/airpurifier.ts
+++ b/src/irdevice/airpurifier.ts
@@ -2,6 +2,7 @@ import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import { request } from 'undici';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, irDevicesConfig, irdevice } from '../settings';
+import { StatusCodeDescription } from '../utils';
 
 /**
  * Platform Accessory
@@ -218,9 +219,9 @@ export class AirPurifier {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
       } catch (e: any) {
@@ -313,43 +314,23 @@ export class AirPurifier {
     return command;
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
+    let statusMsg = `${this.device.remoteType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/irdevice/airpurifier.ts
+++ b/src/irdevice/airpurifier.ts
@@ -219,8 +219,9 @@ export class AirPurifier {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
@@ -318,6 +319,7 @@ export class AirPurifier {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -330,7 +332,7 @@ export class AirPurifier {
         statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/irdevice/camera.ts
+++ b/src/irdevice/camera.ts
@@ -2,6 +2,7 @@ import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import { request } from 'undici';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, irDevicesConfig, irdevice } from '../settings';
+import { StatusCodeDescription } from '../utils';
 
 /**
  * Platform Accessory
@@ -123,9 +124,9 @@ export class Camera {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
       } catch (e: any) {
@@ -199,43 +200,23 @@ export class Camera {
     return command;
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
+    let statusMsg = `${this.device.remoteType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/irdevice/camera.ts
+++ b/src/irdevice/camera.ts
@@ -124,8 +124,9 @@ export class Camera {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
@@ -204,6 +205,7 @@ export class Camera {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -216,7 +218,7 @@ export class Camera {
         statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/irdevice/fan.ts
+++ b/src/irdevice/fan.ts
@@ -244,8 +244,9 @@ export class Fan {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
@@ -338,6 +339,7 @@ export class Fan {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -350,7 +352,7 @@ export class Fan {
         statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/irdevice/fan.ts
+++ b/src/irdevice/fan.ts
@@ -2,6 +2,7 @@ import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import { request } from 'undici';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, irDevicesConfig, irdevice } from '../settings';
+import { StatusCodeDescription } from '../utils';
 
 /**
  * Platform Accessory
@@ -243,9 +244,9 @@ export class Fan {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
       } catch (e: any) {
@@ -333,43 +334,23 @@ export class Fan {
     return command;
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
+    let statusMsg = `${this.device.remoteType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/irdevice/light.ts
+++ b/src/irdevice/light.ts
@@ -148,8 +148,9 @@ export class Light {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.accessory.context.On = this.On;
@@ -229,6 +230,7 @@ export class Light {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -241,7 +243,7 @@ export class Light {
         statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/irdevice/light.ts
+++ b/src/irdevice/light.ts
@@ -2,6 +2,7 @@ import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import { request } from 'undici';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, irDevicesConfig, irdevice } from '../settings';
+import { StatusCodeDescription } from '../utils';
 
 /**
  * Platform Accessory
@@ -147,9 +148,9 @@ export class Light {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.accessory.context.On = this.On;
         this.updateHomeKitCharacteristics();
@@ -224,43 +225,23 @@ export class Light {
     return command;
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
+    let statusMsg = `${this.device.remoteType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/irdevice/other.ts
+++ b/src/irdevice/other.ts
@@ -2,6 +2,7 @@ import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import { request } from 'undici';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, irDevicesConfig, irdevice } from '../settings';
+import { StatusCodeDescription } from '../utils';
 
 /**
  * Platform Accessory
@@ -142,9 +143,9 @@ export class Others {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
       } catch (e: any) {
@@ -218,43 +219,23 @@ export class Others {
     return command;
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
+    let statusMsg = `${this.device.remoteType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/irdevice/other.ts
+++ b/src/irdevice/other.ts
@@ -143,8 +143,9 @@ export class Others {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
@@ -223,6 +224,7 @@ export class Others {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -235,7 +237,7 @@ export class Others {
         statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/irdevice/tv.ts
+++ b/src/irdevice/tv.ts
@@ -376,8 +376,9 @@ export class TV {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
@@ -471,6 +472,7 @@ export class TV {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -483,7 +485,7 @@ export class TV {
         statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/irdevice/tv.ts
+++ b/src/irdevice/tv.ts
@@ -2,6 +2,7 @@ import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import { request } from 'undici';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, irDevicesConfig, irdevice } from '../settings';
+import { StatusCodeDescription } from '../utils';
 
 /**
  * Platform Accessory
@@ -375,9 +376,9 @@ export class TV {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
       } catch (e: any) {
@@ -466,43 +467,23 @@ export class TV {
     return command;
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
+    let statusMsg = `${this.device.remoteType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/irdevice/vacuumcleaner.ts
+++ b/src/irdevice/vacuumcleaner.ts
@@ -2,6 +2,7 @@ import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import { request } from 'undici';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, irDevicesConfig, irdevice } from '../settings';
+import { StatusCodeDescription } from '../utils';
 
 /**
  * Platform Accessory
@@ -119,9 +120,9 @@ export class VacuumCleaner {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
       } catch (e: any) {
@@ -195,43 +196,23 @@ export class VacuumCleaner {
     return command;
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
+    let statusMsg = `${this.device.remoteType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/irdevice/vacuumcleaner.ts
+++ b/src/irdevice/vacuumcleaner.ts
@@ -120,8 +120,9 @@ export class VacuumCleaner {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
@@ -200,6 +201,7 @@ export class VacuumCleaner {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -212,7 +214,7 @@ export class VacuumCleaner {
         statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/irdevice/waterheater.ts
+++ b/src/irdevice/waterheater.ts
@@ -2,6 +2,7 @@ import { CharacteristicValue, PlatformAccessory, Service } from 'homebridge';
 import { request } from 'undici';
 import { SwitchBotPlatform } from '../platform';
 import { Devices, irDevicesConfig, irdevice } from '../settings';
+import { StatusCodeDescription } from '../utils';
 
 /**
  * Platform Accessory
@@ -128,9 +129,9 @@ export class WaterHeater {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
+        this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
-        this.statusCode(statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
       } catch (e: any) {
@@ -204,43 +205,23 @@ export class WaterHeater {
     return command;
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command not supported by this deviceType, statusCode: ${statusCode}`);
-        break;
-      case 152:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Command is not supported, statusCode: ${statusCode}`);
-        break;
-      case 161:
-        this.errorLog(`${this.device.remoteType}: ${this.accessory.displayName} Device is offline, statusCode: ${statusCode}`);
-        break;
-      case 171:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Hub Device is offline, statusCode: ${statusCode}. ` +
-          `Hub: ${this.device.hubDeviceId}`,
-        );
-        break;
-      case 190:
-        this.errorLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Device internal error due to device states not synchronized with server,` +
-          ` Or command format is invalid, statusCode: ${statusCode}`,
-        );
-        break;
-      case 100:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(
-          `${this.device.remoteType}: ${this.accessory.displayName} Unknown statusCode: ` +
-          `${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`,
-        );
+    let statusMsg = `${this.device.remoteType}: ${this.accessory.displayName} ${StatusCodeDescription(statusCode)}`;
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      if (statusCode === 171) {
+        statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
+      }
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/irdevice/waterheater.ts
+++ b/src/irdevice/waterheater.ts
@@ -129,8 +129,9 @@ export class WaterHeater {
           method: 'POST',
           headers: this.platform.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const deviceStatus: any = await body.json();
+        await this.statusCode(deviceStatus.statusCode);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Devices: ${JSON.stringify(deviceStatus.body)}`);
         this.debugLog(`${this.device.remoteType}: ${this.accessory.displayName} Headers: ${JSON.stringify(headers)}`);
         this.updateHomeKitCharacteristics();
@@ -209,6 +210,7 @@ export class WaterHeater {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -221,7 +223,7 @@ export class WaterHeater {
         statusMsg =`${statusMsg}, Hub: ${this.device.hubDeviceId}`;
       }
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -301,8 +301,9 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
         const { body, statusCode, headers } = await request(Devices, {
           headers: this.generateHeaders(),
         });
-        this.statusCode(statusCode);
+        await this.statusCode(statusCode);
         const devicesAPI: any = await body.json();
+        await this.statusCode(devicesAPI.statusCode);
         this.debugLog(`Devices: ${JSON.stringify(devicesAPI.body)}`);
         this.debugLog(`Headers: ${JSON.stringify(headers)}`);
         // SwitchBot Devices
@@ -2156,6 +2157,7 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
    * Logs the status code and throws an error if the status code is invalid.
    *
    * @param statusCode - The status code to be validated.
+   * @returns {Promise<void>} - Resolves if the status code is valid, otherwise rejects with an error.
    * @throws {Error} If the provided status code is not valid.
    */
   async statusCode(statusCode: number): Promise<void> {
@@ -2165,7 +2167,7 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
       this.debugLog(statusMsg);
     } else {
       this.errorLog(statusMsg);
-      throw new Error(`Invalid Status Code: ${statusCode}`);
+      return Promise.reject(new Error(`Invalid Status Code: ${statusCode}`));
     }
   }
 

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -33,6 +33,7 @@ import { WaterHeater } from './irdevice/waterheater';
 import { readFileSync, writeFileSync } from 'fs';
 import { API, Characteristic, DynamicPlatformPlugin, Logger, PlatformAccessory, Service } from 'homebridge';
 import { Devices, PLATFORM_NAME, PLUGIN_NAME, SwitchBotPlatformConfig, device, devicesConfig, irDevicesConfig, irdevice } from './settings';
+import { StatusCodeDescription } from './utils';
 
 /**
  * HomebridgePlatform
@@ -2151,38 +2152,20 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
     this.warnLog(`Removing existing accessory from cache: ${existingAccessory.displayName}`);
   }
 
+  /**
+   * Logs the status code and throws an error if the status code is invalid.
+   *
+   * @param statusCode - The status code to be validated.
+   * @throws {Error} If the provided status code is not valid.
+   */
   async statusCode(statusCode: number): Promise<void> {
-    switch (statusCode) {
-      case 151:
-        this.errorLog(
-          `Command not supported by this device type, statusCode: ${statusCode}, Submit Feature Request Here: ` +
-          'https://tinyurl.com/SwitchBotFeatureRequest',
-        );
-        break;
-      case 152:
-        this.errorLog(`Device not found, statusCode: ${statusCode}`);
-        break;
-      case 160:
-        this.errorLog(`Command is not supported, statusCode: ${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`);
-        break;
-      case 161:
-        this.errorLog(`Device is offline, statusCode: ${statusCode}`);
-        break;
-      case 171:
-        this.errorLog(`is offline, statusCode: ${statusCode}`);
-        break;
-      case 190:
-        this.errorLog(`Requests reached the daily limit, statusCode: ${statusCode}`);
-        break;
-      case 100:
-        this.debugLog(`Command successfully sent, statusCode: ${statusCode}`);
-        break;
-      case 200:
-        this.debugLog(`Request successful, statusCode: ${statusCode}`);
-        break;
-      default:
-        this.infoLog(`Unknown statusCode, statusCode: ${statusCode}, Submit Bugs Here: ' + 'https://tinyurl.com/SwitchBotBug`);
-        throw new Error(`Unknown Status Code: ${statusCode}`);
+    const statusMsg = StatusCodeDescription(statusCode);
+
+    if (statusCode === 100 || statusCode === 200) {
+      this.debugLog(statusMsg);
+    } else {
+      this.errorLog(statusMsg);
+      throw new Error(`Invalid Status Code: ${statusCode}`);
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,50 @@
 export function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
+
+/**
+ * Returns a human-readable description for the given status code.
+ *
+ * @param statusCode - The status code for which to retrieve the description.
+ * @returns A description corresponding to the provided status code.
+ */
+export function StatusCodeDescription(statusCode: number): string {
+  switch (statusCode) {
+    case 151:
+      return `Command not supported by this deviceType, statusCode: ${statusCode}, Submit Bugs Here: https://tinyurl.com/SwitchBotBug`;
+    case 152:
+      return `Device not found, statusCode: ${statusCode}`;
+    case 160:
+      return `Command is not supported, statusCode: ${statusCode}, Submit Bugs Here: https://tinyurl.com/SwitchBotBug`;
+    case 161:
+      return `Device is offline, statusCode: ${statusCode}`;
+    case 171:
+      return `Hub Device is offline, statusCode: ${statusCode}`;
+    case 190:
+      return `Device internal error due to device states not synchronized with server or command format is invalid, statusCode: ${statusCode}`;
+    case 100:
+      return `Command successfully sent, statusCode: ${statusCode}`;
+    case 200:
+      return `Request successful, statusCode: ${statusCode}`;
+    case 400:
+      return `Bad Request, statusCode: ${statusCode}, Submit Bugs Here: https://tinyurl.com/SwitchBotBug`;
+    case 401:
+      return `Unauthorized, statusCode: ${statusCode}`;
+    case 403:
+      return `Forbidden, statusCode: ${statusCode}`;
+    case 404:
+      return `Not Found, statusCode: ${statusCode}`;
+    case 406:
+      return `Not Acceptable, statusCode: ${statusCode}`;
+    case 415:
+      return `Unsupported Media Type, statusCode: ${statusCode}`;
+    case 422:
+      return `Unprocessable Entity, statusCode: ${statusCode}`;
+    case 429:
+      return `Too Many Requests, statusCode: ${statusCode}`;
+    case 500:
+      return `Internal Server Error, statusCode: ${statusCode}`;
+    default:
+      return `Unknown statusCode, statusCode: ${statusCode}, Submit Bugs Here: https://tinyurl.com/SwitchBotBug`;
+  }
+}


### PR DESCRIPTION
This will only throw an error if the server returns an unknown status code. I'm wondering if it should throw an error on any status code that does not equal `100` or `200` or maybe just codes >200?

