### PR TITLE
Hide MotionSensor from curtains

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -463,6 +463,13 @@
                         "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Curtain' && model.options.devices[arrayIndices].deviceId);"
                       }
                     },
+                    "hide_motionsensor": {
+                      "title": "Hide Motion Sensor",
+                      "type": "boolean",
+                      "condition": {
+                        "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Curtain' && model.options.devices[arrayIndices].deviceId);"
+                      }
+                    },
                     "set_minlux": {
                       "title": "Set Min Lux",
                       "type": "number",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -93,6 +93,7 @@ export type humidifier = {
 export type curtain = {
   disable_group?: boolean;
   hide_lightsensor?: boolean;
+  hide_motionsensor?: boolean;
   set_minLux?: number;
   set_maxLux?: number;
   updateRate?: number;


### PR DESCRIPTION
## :recycle: Current situation

I don't have any need for a motion sensor to be made visible for my device.  I'd like to be able to disable it if I can.

## :bulb: Proposed solution

Add a configurable setting to disable the motion sensor being exposed & published.

## :gear: Release Notes

Allowed the motion sensor for curtains to be hidden.

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
