### PR TITLE
Fix BLE model identifier for iosensor.

### DIFF
--- a/src/device/iosensor.ts
+++ b/src/device/iosensor.ts
@@ -290,7 +290,7 @@ export class IOSensor {
     if (switchbot !== false) {
       switchbot
         .startScan({
-          model: 'i',
+          model: 'w',
           id: this.device.bleMac,
         })
         .then(async () => {


### PR DESCRIPTION
## :recycle: Current situation

The iosensor module uses the wrong identifier for BLE. 

## :bulb: Proposed solution

Use the correct identifier ("w"), instead of "i" which is the identifier of the meterplus.

## :gear: Release Notes

- Fix Bluetooth LE support for iosensor.

## :heavy_plus_sign: Additional Information
Related #808 

### Testing
None.

### Reviewer Nudging
None.