### PR TITLE
fix for lux Characteristic not usable with fakegato history type 'roo…

### DIFF
--- a/src/device/hub.ts
+++ b/src/device/hub.ts
@@ -391,10 +391,18 @@ export class Hub {
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} updateCharacteristic CurrentTemperature: ${this.CurrentTemperature}`);
       }
     }
+
+    // CurrentAmbientLightLevel
     if (!this.device.hub?.hide_lightsensor) {
       if (this.CurrentAmbientLightLevel === undefined) {
         this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} CurrentAmbientLightLevel: ${this.CurrentAmbientLightLevel}`);
       } else {
+        if (this.device.mqttURL) {
+          mqttmessage.push(`"light": ${this.CurrentAmbientLightLevel}`);
+        }
+        if (this.device.history) {
+          entry['lux'] = this.CurrentAmbientLightLevel;
+        }
         this.accessory.context.CurrentAmbientLightLevel = this.CurrentAmbientLightLevel;
         this.lightSensorService?.updateCharacteristic(this.platform.Characteristic.CurrentAmbientLightLevel, this.CurrentAmbientLightLevel);
         this.debugLog(
@@ -476,7 +484,7 @@ export class Hub {
       .join(':')
       .toLowerCase();
     this.historyService = device.history
-      ? new this.platform.fakegatoAPI('room', this.accessory, {
+      ? new this.platform.fakegatoAPI('custom', this.accessory, {
         log: this.platform.log,
         storage: 'fs',
         filename: `${hostname().split('.')[0]}_${mac}_persist.json`,
@@ -594,6 +602,11 @@ export class Hub {
       this.CurrentTemperature = 0;
     } else {
       this.CurrentTemperature = this.accessory.context.CurrentTemperature;
+    }
+    if (this.CurrentAmbientLightLevel === undefined) {
+      this.CurrentAmbientLightLevel = this.set_minLux;
+    } else {
+      this.CurrentAmbientLightLevel = this.accessory.context.CurrentAmbientLightLevel;
     }
     if (this.FirmwareRevision === undefined) {
       this.FirmwareRevision = this.platform.version;


### PR DESCRIPTION
…m' and work with 'custom'

## :recycle: Current situation

*lux not working with hub2 and fakegato history*

## :bulb: change type from 'room' to 'custom' work for temp, humidity and lux for now 

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

## :heavy_plus_sign: Additional Information
*'room' type seems to not having  lux management , fakegato historty seems to choose to set it in customm for those type of 'custom' devide .
Pull Resquest: https://github.com/simont77/fakegato-history/pull/128*

### Testing

*working on my raspberry*
begginer, I made a personnal  dev workflow , surely not good... 

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*
