### PR TITLE
Remove patch Node.js version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "engines": {
     "homebridge": "^1.6.1",
-    "node": "^18.18.2 || ^20.8.1"
+    "node": "^18 || ^20",
   },
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
## :recycle: Current situation
Updating the plug-in often shows warnings in Homebridge Config X and also in the logs when the minimum Node.js patch version increases.

## :bulb: Proposed solution
Use only the major version, similar to this:
https://github.com/homebridge/homebridge-config-ui-x/pull/1570/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R31

Fixes https://github.com/OpenWonderLabs/homebridge-switchbot/issues/837.