### PR TITLE
Added webhook event listener.

### DIFF
--- a/src/device/meter.ts
+++ b/src/device/meter.ts
@@ -157,6 +157,27 @@ export class Meter {
       .subscribe(async () => {
         await this.refreshStatus();
       });
+
+    //regisiter webhook event handler
+    if (this.device.webhook) {
+      this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} is listening webhook.`);
+      this.platform.webhookEventHandler[this.device.deviceId] = async (context) => {
+	try {
+	  this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} received Webhook: ${JSON.stringify(context)}`);
+	  if (context.scale === 'CELSIUS') {
+	    this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} ` +
+			  `(temperature, humidity) = ` +
+			  `Webhook:(${context.temperature}, ${context.humidity}), ` +
+			  `current:(${this.CurrentTemperature}, ${this.CurrentRelativeHumidity})`);
+	    this.CurrentRelativeHumidity = context.humidity;
+	    this.CurrentTemperature = context.temperature;
+	    this.updateHomeKitCharacteristics();
+	  }
+	} catch (e: any) {
+	  this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} failed to handle webhook. Received: ${JSON.stringify(context)} Error: ${e}`);
+	}
+      }
+    }
   }
 
   /**

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -29,6 +29,9 @@ import { Buffer } from 'buffer';
 import { queueScheduler } from 'rxjs';
 import fakegato from 'fakegato-history';
 import { EveHomeKitTypes } from 'homebridge-lib';
+import { MqttClient } from 'mqtt';
+import { connectAsync } from 'async-mqtt';
+import * as http from 'http';
 
 import { readFileSync, writeFileSync } from 'fs';
 import { API, DynamicPlatformPlugin, Logger, PlatformAccessory, Service, Characteristic } from 'homebridge';
@@ -49,9 +52,12 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
   version = process.env.npm_package_version || '2.9.0';
   debugMode!: boolean;
   platformLogging?: string;
+  webhookEventListener: http.Server | null = null;
+  mqttClient: MqttClient | null = null;
 
   public readonly fakegatoAPI: any;
   public readonly eve: any;
+  public readonly webhookEventHandler: {[x: string]: (context: {[x: string]: any}) => void} = {};
 
   constructor(
     public readonly log: Logger,
@@ -108,8 +114,183 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
         this.debugErrorLog(`Failed to Discover, Error: ${e}`);
       }
     });
+
+    this.setupMqtt();
+    this.setupwebhook();
   }
 
+  async setupMqtt(): Promise<void> {
+    if (this.config.options?.mqttURL) {
+      try {
+        this.mqttClient = await connectAsync(this.config.options?.mqttURL, this.config.options.mqttOptions || {});
+        this.debugLog(`MQTT connection has been established successfully.`);
+        this.mqttClient.on('error', (e: Error) => {
+          this.errorLog(`Failed to publish MQTT messages. ${e}`);
+        });
+	if (!this.config.options?.webhookURL) {
+	  // receive webhook events via MQTT
+          this.infoLog(`Webhook is configured to be received through ${this.config.options.mqttURL}/homebridge-switchbot/webhook.`);
+	  this.mqttClient.subscribe(`homebridge-switchbot/webhook/+`);
+	  this.mqttClient.on('message', async (topic: string, message) => {
+	    try {
+	      this.debugLog(`Received Webhook via MQTT: ${topic}=${message}`)
+	      const context = JSON.parse(message.toString());
+	      await this.webhookEventHandler[context.deviceMac]?.(context);
+	    } catch (e: any) {
+	      this.errorLog(`Failed to handle webhook event. Error:${e}`);
+	    }
+	  })
+	}
+      } catch (e) {
+        this.mqttClient = null;
+        this.errorLog(`Failed to establish MQTT connection. ${e}`);
+      }
+    }
+  }
+
+  async setupwebhook() {
+    //webhook configutation
+    if (this.config.options?.webhookURL) {
+      const url = this.config.options?.webhookURL;
+
+      try {
+	const xurl = new URL(url);
+	const port = Number(xurl.port);
+	const path = xurl.pathname;
+	this.webhookEventListener = http.createServer((request: http.IncomingMessage, response: http.ServerResponse) => {
+	  try {
+	    if (request.url === path && request.method === 'POST') {
+	      request.on('data', async (data) => {
+		try {
+		  const body = JSON.parse(data);
+		  this.debugLog(`Received Webhook: ${JSON.stringify(body)}`)
+		  if (this.config.options?.mqttURL) {
+		    const mac = body.context.deviceMac
+	              ?.toLowerCase()
+		      .match(/[\s\S]{1,2}/g)
+	              ?.join(':');
+		    const options = this.config.options?.mqttPubOptions || {};
+		    this.mqttClient?.publish(`homebridge-switchbot/webhook/${mac}`, `${JSON.stringify(body.context)}`, options);
+		  }
+		  await this.webhookEventHandler[body.context.deviceMac]?.(body.context);
+		} catch (e: any) {
+		  this.errorLog(`Failed to handle webhook event. Error:${e}`);
+		}
+	      })
+	      response.writeHead(200, {'Content-Type': 'text/plain'});
+	      response.end(`OK`);
+	    }
+	    // else {
+	    //   response.writeHead(403, {'Content-Type': 'text/plain'});
+	    //   response.end(`NG`);
+	    // }
+	  } catch (e: any) {
+	    this.errorLog(`Failed to handle webhook event. Error:${e}`);
+	  }
+	}).listen(port ? port : 80);
+      } catch (e: any) {
+	this.errorLog(`Failed to create webhook listener. Error:${e.message}`);
+	return;
+      }
+      
+      try {
+	const {body, statusCode, headers} = await request(
+	  'https://api.switch-bot.com/v1.1/webhook/setupWebhook', {
+	    method: 'POST',
+            headers: this.generateHeaders(),
+	    body: JSON.stringify({
+	      'action': 'setupWebhook',
+	      'url': url,
+	      'deviceList': 'ALL',
+	    })
+	  })
+	const response: any = await body.json();
+        this.debugLog(`setupWebhook: url:${url}`);
+        this.debugLog(`setupWebhook: body:${JSON.stringify(response)}`);
+        this.debugLog(`setupWebhook: statusCode:${statusCode}`);
+        this.debugLog(`setupWebhook: headers:${JSON.stringify(headers)}`);
+	if (statusCode !== 200 || response?.statusCode !== 100) {
+          this.errorLog(`Failed to configure webhook. Existing webhook well be overridden. HTTP:${statusCode} API:${response?.statusCode} message:${response?.message}`);
+	}
+      } catch(e: any) {
+        this.errorLog(`Failed to configure webhook. Error: ${e.message}`);
+      }
+
+      try {
+	const {body, statusCode, headers} = await request(
+	  'https://api.switch-bot.com/v1.1/webhook/updateWebhook', {
+	    method: 'POST',
+            headers: this.generateHeaders(),
+	    body: JSON.stringify({
+	      'action': 'updateWebhook',
+	      'config': {
+		'url': url,
+		'enable': true,
+	      }
+	    })
+	  })
+	const response: any = await body.json();
+        this.debugLog(`updateWebhook: url:${url}`);
+        this.debugLog(`updateWebhook: body:${JSON.stringify(response)}`);
+        this.debugLog(`updateWebhook: statusCode:${statusCode}`);
+        this.debugLog(`updateWebhook: headers:${JSON.stringify(headers)}`);
+	if (statusCode !== 200 || response?.statusCode !== 100) {
+          this.errorLog(`Failed to update webhook. HTTP:${statusCode} API:${response?.statusCode} message:${response?.message}`);
+	}
+      } catch(e: any) {
+        this.errorLog(`Failed to update webhook. Error:${e.message}`);
+      }
+
+      try {
+	const {body, statusCode, headers} = await request(
+	  'https://api.switch-bot.com/v1.1/webhook/queryWebhook', {
+	    method: 'POST',
+            headers: this.generateHeaders(),
+	    body: JSON.stringify({
+	      'action': 'queryUrl',
+	    })
+	  })
+	const response: any = await body.json();
+        this.debugLog(`queryWebhook: body:${JSON.stringify(response)}`);
+        this.debugLog(`queryWebhook: statusCode:${statusCode}`);
+        this.debugLog(`queryWebhook: headers:${JSON.stringify(headers)}`);
+	if (statusCode !== 200 || response?.statusCode !== 100) {
+          this.errorLog(`Failed to query webhook. HTTP:${statusCode} API:${response?.statusCode} message:${response?.message}`);
+	} else {
+          this.infoLog(`Listening webhook on ${response?.body?.urls[0]}`);
+	}
+      } catch (e: any) {
+        this.errorLog(`Failed to query webhook. Error:${e}`);
+      }
+
+      this.api.on('shutdown', async () => {
+	try {
+	  const {body, statusCode, headers} = await request(
+	    'https://api.switch-bot.com/v1.1/webhook/deleteWebhook', {
+	      method: 'POST',
+              headers: this.generateHeaders(),
+	      body: JSON.stringify({
+		'action': 'deleteWebhook',
+		'url': url,
+	      })
+	    })
+	  const response: any = await body.json();
+          this.debugLog(`deleteWebhook: url:${url}`);
+          this.debugLog(`deleteWebhook: body:${JSON.stringify(response)}`);
+          this.debugLog(`deleteWebhook: statusCode:${statusCode}`);
+          this.debugLog(`deleteWebhook: headers:${JSON.stringify(headers)}`);
+	  if (statusCode !== 200 || response?.statusCode !== 100) {
+            this.errorLog(`Failed to delete webhook. HTTP:${statusCode} API:${response?.statusCode} message:${response?.message}`);
+	  } else {
+            this.infoLog(`Unregistered webhook to close listening.`);
+	  }
+	} catch (e: any) {
+          this.errorLog(`Failed to delete webhook. Error:${e.message}`);
+	}
+      })
+    }
+  }
+  
   /**
    * This function is invoked when homebridge restores cached accessories from disk at startup.
    * It should be used to setup event handlers for characteristics and update respective values.

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -35,6 +35,10 @@ export type options = {
   logging?: string;
   devices?: Array<devicesConfig>;
   irdevices?: Array<irDevicesConfig>;
+  webhookURL?: string;
+  mqttURL?: string;
+  mqttOptions?: IClientOptions;
+  mqttPubOptions?: IClientOptions;
 };
 
 export interface devicesConfig extends device {
@@ -56,6 +60,7 @@ export interface devicesConfig extends device {
   mqttOptions?: IClientOptions;
   mqttPubOptions?: IClientOptions;
   history?: boolean;
+  webhook?: boolean;
   bot?: bot;
   meter?: meter;
   humidifier?: humidifier;


### PR DESCRIPTION
To donavanbecker,

If this PR doesn't agree to the strategy/policy of plug-in and/or target user, reject it immediately. I guess there are any reasons for the absence of this function.

To developers,

This PR implements webhook event listener to deliver them to the handler of each device, as a basis of future development.

Config keyword 'webhookURL' in 'options' is added to specify webhook URL which needs to be public server address where the plug-in is running.

~~~
{
  "name": "SwitchBot",
  "credentials": {...},
  "options": {
    "webhookURL": "http://${FQDN}:${PORT}/${PATH}",
  }
  ...
}
~~~
where ${PATH} is an any string (e.g. 'switchbot/webhook'). It's better than unique URL in security. No response to wrong URL (i.e. 403) is also from the same reason.

URL configuration consists of setupWebhook/updateWebhook/queryWebhook, and existing URL is overridden. The URL will be deleted in exiting of the plug-in (i.e. deleteWebhook).

To implement the webhook event handler, look constructor() in meter.ts as an example. The template code structure is as follows.

~~~
if (this.device.webhook) {
  this.infoLog(`${this.device.deviceType}: ${this.accessory.displayName} is listening webhook.`);
  this.platform.webhookEventHandler[this.device.deviceId] = async (context) => {
    try {
      this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} received Webhook: ${JSON.stringify(context)}`);
      // 
      // event processing in here.
      // 
    } catch (e: any) {
      this.errorLog(`${this.device.deviceType}: ${this.accessory.displayName} failed to handle webhook. Received: ${JSON.stringify(context)} Error: ${e}`);
    }
  }
}
~~~

and the device handler is enabled by config keyword 'webhook' of device in 'devices' section.

~~~
"devices":[
  {
    "deviceId": "...",
    "webhook": true,
    ...
  },
  ...	
]
~~~
Note that webhook events are asynchronous, and have to manage the concurrency with regular operations (e.g. poling). The latency is not so small, and about 5 to 10 seconds for curtain device in my experience. Also note that 'timeOfSample' in the events are not always increasing, and may need to skip 'past' events in the implementation.

For debugging purpose, this PR also added the function to publish webhook events to MQTT broker. Use config keyword 'mqttURL' in 'options' as well as for device.
~~~
  "options": {
    "webhookURL": "http://${FQDN}:${PORT}/${PATH}",
    "mqttURL": "mqtt://${BROKER}",
  }
~~~
Specifying both of 'webhookURL' and 'mqttURL', webhook events are redircted  to the broker, and can be examined using any browser applications.

Specifying the redircted broker address in 'mqttURL' w/o 'webhookURL',
~~~
  "options": {
    "mqttURL": "mqtt://${BROKER}",
  }
~~~
redirected webhook events trigger the webhook event handlers. Furthermore, you can  manually publish webhook events. This is very helpfull for the development.