### PR TITLE
Fix noble

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,8 +64,8 @@
     "undici": "^5.27.2"
   },
   "optionalDependencies": {
-    "@abandonware/bluetooth-hci-socket": "^1.2.0",
-    "@abandonware/noble": "^1.13.5",
+    "@abandonware/bluetooth-hci-socket": "^0.5.3-10",
+    "@abandonware/noble": "^1.9.2-23",
     "node-switchbot": "^1.9.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## :recycle: Current situation

Noble is broken in `v2.11.0` with invalid version numbers.

## :bulb: Proposed solution

Use the `v2.10.0` version numbers.
