### PR TITLE
Revert script name change

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "check": "npm install && npm outdated",
     "update": "ncu -u && npm update && npm install",
-    "update dependencies": "npm run check && npm run update",
+    "updateDependencies": "npm run check && npm run update",
     "lint": "eslint src/**.ts",
     "jlint": "eslint homebridge-ui/public/**.mjs",
     "watch": "npm run build && npm run plugin-ui && npm link && nodemon",


### PR DESCRIPTION
This looks like it might be a mistake, running `npm run update dependences` will just run `npm run update`. `npm run "update dependences"` works, but doesn't seem ideal.