### PR TITLE
Fix BLE connection

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2525,13 +2525,14 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
   }
 
   // BLE Connection
-  connectBLE() {
+  async connectBLE() {
     let Switchbot: new () => any;
     let switchbot: any;
     try {
-      Switchbot = require('node-switchbot');
+      Switchbot = (await import('node-switchbot')).default;
       queueScheduler.schedule(() => (switchbot = new Switchbot()));
     } catch (e: any) {
+      this.log.error(e);
       switchbot = false;
       this.errorLog(`Was 'node-switchbot' found: ${switchbot}`);
     }


### PR DESCRIPTION
## :recycle: Current situation
The `require` function is not supported with ESM, leading the following error:
```
ReferenceError: require is not defined
```

## :bulb: Proposed solution

Use a dynamic import.