### PR TITLE
Fix BLE curtain mode

### DIFF
--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -36,9 +36,9 @@ export class Curtain {
   OpenAPI_CurrentPosition: deviceStatus['slidePosition'];
   OpenAPI_CurrentAmbientLightLevel: deviceStatus['brightness'];
 
-  // OpenAPI Others
+  // Others
   Mode!: string;
-  setPositionMode?: string | number;
+  setPositionMode?: string;
 
   // BLE Status
   BLE_InMotion: serviceData['inMotion'];
@@ -675,10 +675,7 @@ export class Curtain {
         .toLowerCase();
       this.debugLog(`${this.device.deviceType}: ${this.accessory.displayName} BLE Address: ${this.device.bleMac}`);
       this.SilentPerformance();
-      const adjustedMode = this.setPositionMode || null;
-      if (adjustedMode === null) {
-        this.Mode = 'Default Mode';
-      }
+      const adjustedMode = this.setPositionMode == '1' ? 0x01 : 0xff;
       this.debugLog(`${this.accessory.displayName} Mode: ${this.Mode}`);
       if (switchbot !== false) {
         await this.retry({
@@ -1033,18 +1030,18 @@ export class Curtain {
   async SilentPerformance() {
     if (Number(this.TargetPosition) > 50) {
       if (this.device.curtain?.setOpenMode === '1') {
-        this.setPositionMode = 1;
+        this.setPositionMode = '1';
         this.Mode = 'Silent Mode';
       } else {
-        this.setPositionMode = 0;
+        this.setPositionMode = '0';
         this.Mode = 'Performance Mode';
       }
     } else {
       if (this.device.curtain?.setCloseMode === '1') {
-        this.setPositionMode = 1;
+        this.setPositionMode = '1';
         this.Mode = 'Silent Mode';
       } else {
-        this.setPositionMode = 0;
+        this.setPositionMode = '0';
         this.Mode = 'Performance Mode';
       }
     }


### PR DESCRIPTION
## :recycle: Current situation

If the curtain mode was not defined in the settings the following error would occur:
```
Curtain: Curtain failed BLEpushChanges with BLE Connection, Error Message: "The type of running mode is incorrect: object"
```

## :bulb: Proposed solution

- Set position mode to strings 
- Remove redundant code
- Set proper values for node-switchbot
