### PR TITLE
Fix curtain characteristic warning

### DIFF
--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -155,16 +155,6 @@ export class Curtain {
       })
       .onSet(this.TargetPositionSet.bind(this));
 
-    this.windowCoveringService
-      .getCharacteristic(this.hap.Characteristic.HoldPosition)
-      .setProps({
-        minStep: this.minStep(device),
-        minValue: 0,
-        maxValue: 100,
-        validValueRanges: [0, 100],
-      })
-      .onSet(this.HoldPositionSet.bind(this));
-
     // Light Sensor Service
     if (device.curtain?.hide_lightsensor) {
       this.debugLog(`${this.device.deviceType}: ${accessory.displayName} Removing Light Sensor Service`);


### PR DESCRIPTION
## :recycle: Current situation

The following error appears:
```
This plugin threw an error from the characteristic 'Hold Position': Characteristic Property 'minValue' can only be set for characteristics with numeric format, but not for bool. See https://homebridge.io/w/JtMGR for more info.
This plugin threw an error from the characteristic 'Hold Position': Characteristic Property 'maxValue' can only be set for characteristics with numeric format, but not for bool. See https://homebridge.io/w/JtMGR for more info.
This plugin threw an error from the characteristic 'Hold Position': Characteristic Property `minStep` can only be set for characteristics with numeric format, but not for bool. See https://homebridge.io/w/JtMGR for more info.
```

## :bulb: Proposed solution

Remove the `setProps` call.
