### PR TITLE
v3.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
-## [3.2.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v3.2.0) (2024-02-XX)
+## [3.2.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v3.2.0) (2024-02-06)
 
 ### What's Changed
 - Upgrade to latest node-switchbot with is now a Typescript ES-Module.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file. This project uses [Semantic Versioning](https://semver.org/)
 
+## [3.2.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v3.2.0) (2024-02-XX)
+
+### What's Changed
+- Upgrade to latest node-switchbot with is now a Typescript ES-Module.
+- Housekeeping and updated dependencies.
+
+**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v3.1.2...v3.2.0
+
 ## [3.1.2](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v3.1.2) (2024-02-05)
 
 ### What's Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,7 @@
         "node": "^18 || ^20"
       },
       "optionalDependencies": {
-        "node-switchbot": "^1.10.0"
+        "node-switchbot": "^2.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3314,9 +3314,9 @@
       }
     },
     "node_modules/engine.io-parser": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.1.tgz",
-      "integrity": "sha512-9JktcM3u18nU9N2Lz3bWeBgxVgOKpw7yhRaoxQA3FUDZzzw+9WlA6p4G4u0RixNkg14fH7EfEc/RhpurtiROTQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.2.tgz",
+      "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
@@ -6934,9 +6934,9 @@
       }
     },
     "node_modules/node-switchbot": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/node-switchbot/-/node-switchbot-1.10.0.tgz",
-      "integrity": "sha512-na7yfPQWdDCxRdrLBUAgu6AHRiSOmihwGK8DbhsFGlNSVWsWcd0bpbYUV1jRGYKWMMYWkhYHoh1t2wJYRirnNg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/node-switchbot/-/node-switchbot-2.0.0.tgz",
+      "integrity": "sha512-uH3vY2nuUjGwHLAPd/uR2oRlyutWabC+lZYYGEOkvKcShAHwu9ZJp/ts1ecpx6uweXLtXsz5m3HoD6N2YZMjYg==",
       "optional": true,
       "dependencies": {
         "@abandonware/noble": "^1.9.2-23"

--- a/package-lock.json
+++ b/package-lock.json
@@ -679,6 +679,18 @@
         "node-pre-gyp": "bin/node-pre-gyp"
       }
     },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "optional": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/@mapbox/node-pre-gyp/node_modules/brace-expansion": {
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
@@ -707,6 +719,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "optional": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@mapbox/node-pre-gyp/node_modules/minimatch": {
@@ -1814,15 +1839,14 @@
       }
     },
     "node_modules/agent-base": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
-      "devOptional": true,
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
+      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
       "dependencies": {
-        "debug": "4"
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": ">= 6.0.0"
+        "node": ">= 14"
       }
     },
     "node_modules/agentkeepalive": {
@@ -4244,29 +4268,6 @@
         "node": ">=14"
       }
     },
-    "node_modules/gaxios/node_modules/agent-base": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.0.tgz",
-      "integrity": "sha512-o/zjMZRhJxny7OyEF+Op8X+efiELC7k7yOjMzgfzVqOzXqkBkWI79YoTdOtsuWd5BWhAGAuOY/Xa6xpiaWXiNg==",
-      "dependencies": {
-        "debug": "^4.3.4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/gaxios/node_modules/https-proxy-agent": {
-      "version": "7.0.2",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
-      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
-      "dependencies": {
-        "agent-base": "^7.0.2",
-        "debug": "4"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/gcp-metadata": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
@@ -4933,6 +4934,18 @@
         "node": ">= 6"
       }
     },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/http2-wrapper": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.1.tgz",
@@ -4947,16 +4960,15 @@
       }
     },
     "node_modules/https-proxy-agent": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
-      "devOptional": true,
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-NmLNjm6ucYwtcUmL7JQC1ZQ57LmHP4lT15FQ8D61nak1rO6DH+fz5qNK2Ap5UN4ZapYICE3/0KodcLYSPsPbaA==",
       "dependencies": {
-        "agent-base": "6",
+        "agent-base": "^7.0.2",
         "debug": "4"
       },
       "engines": {
-        "node": ">= 6"
+        "node": ">= 14"
       }
     },
     "node_modules/humanize-ms": {
@@ -6020,6 +6032,31 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
+    "node_modules/make-fetch-happen/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/make-fetch-happen/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/make-fetch-happen/node_modules/lru-cache": {
       "version": "7.18.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.18.3.tgz",
@@ -6534,6 +6571,18 @@
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
       }
     },
+    "node_modules/node-gyp/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/node-gyp/node_modules/are-we-there-yet": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-3.0.1.tgz",
@@ -6675,6 +6724,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/node-gyp/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/node-gyp/node_modules/lru-cache": {
@@ -8735,6 +8797,18 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/socks-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
       }
     },
     "node_modules/socks/node_modules/ip": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@switchbot/homebridge-switchbot",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@switchbot/homebridge-switchbot",
-      "version": "3.1.3",
+      "version": "3.2.0",
       "funding": [
         {
           "type": "Paypal",
@@ -44,7 +44,7 @@
         "node": "^18 || ^20"
       },
       "optionalDependencies": {
-        "node-switchbot": "^2.0.0"
+        "node-switchbot": "^2.0.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -6936,12 +6936,12 @@
       }
     },
     "node_modules/node-switchbot": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/node-switchbot/-/node-switchbot-2.0.0.tgz",
-      "integrity": "sha512-uH3vY2nuUjGwHLAPd/uR2oRlyutWabC+lZYYGEOkvKcShAHwu9ZJp/ts1ecpx6uweXLtXsz5m3HoD6N2YZMjYg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/node-switchbot/-/node-switchbot-2.0.1.tgz",
+      "integrity": "sha512-k5YsV/ifPwbs/3X1WH7W/fXVwG8uR5VwLskSjviN75T+HJxGUq3KI025OYDnFWxq9jQIrm5U6Fzvo5Q/MCzCqQ==",
       "optional": true,
       "dependencies": {
-        "@abandonware/noble": "^1.9.2-23"
+        "@abandonware/noble": "^1.9.2-24"
       },
       "optionalDependencies": {
         "@abandonware/bluetooth-hci-socket": "^0.5.3-10"

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "undici": "^6.6.1"
   },
   "optionalDependencies": {
-    "node-switchbot": "^1.10.0"
+    "node-switchbot": "^2.0.0"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "SwitchBot",
   "name": "@switchbot/homebridge-switchbot",
-  "version": "3.1.3",
+  "version": "3.2.0",
   "description": "The SwitchBot plugin allows you to access your SwitchBot device(s) from HomeKit.",
   "author": {
     "name": "SwitchBot",
@@ -84,7 +84,7 @@
     "undici": "^6.6.2"
   },
   "optionalDependencies": {
-    "node-switchbot": "^2.0.0"
+    "node-switchbot": "^2.0.1"
   },
   "devDependencies": {
     "@types/node": "^20.11.16",

--- a/src/custom.d.ts
+++ b/src/custom.d.ts
@@ -1,0 +1,2 @@
+declare module 'homebridge-lib'
+declare module 'fakegato-history'

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -39,7 +39,6 @@ import asyncmqtt from 'async-mqtt';
 import crypto, { randomUUID } from 'crypto';
 import { readFileSync, writeFileSync } from 'fs';
 import hbLib from 'homebridge-lib';
-/*import { SwitchBot } from '/Users/Shared/GitHub/OpenWonderLabs/node-switchbot/dist/switchbot.js';*/
 
 
 
@@ -2528,6 +2527,7 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
     try {
       noble = (await import('@abandonware/noble')).default;
       SwitchBot = (await import('node-switchbot')).default;
+      //SwitchBot = (await import('/Users/Shared/GitHub/OpenWonderLabs/node-switchbot/dist/switchbot.js')).default;
       queueScheduler.schedule(() => (switchbot = new SwitchBot({ 'noble': noble })));
     } catch (e: any) {
       switchbot = false;


### PR DESCRIPTION
## [3.2.0](https://github.com/OpenWonderLabs/homebridge-switchbot/releases/tag/v3.2.0) (2024-02-06)

### What's Changed
- Upgrade to latest node-switchbot with is now a Typescript ES-Module.
- Housekeeping and updated dependencies.

**Full Changelog**: https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v3.1.3...v3.2.0