### PR TITLE
Fix node-switchbot import

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2521,14 +2521,10 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
 
   // BLE Connection
   async connectBLE() {
-    let noble: any;
-    let SwitchBot: any;
     let switchbot: any;
     try {
-      noble = (await import('@abandonware/noble')).default;
-      SwitchBot = (await import('node-switchbot')).default;
-      //SwitchBot = (await import('/Users/Shared/GitHub/OpenWonderLabs/node-switchbot/dist/switchbot.js')).default;
-      queueScheduler.schedule(() => (switchbot = new SwitchBot({ 'noble': noble })));
+      const SwitchBot = (await import('node-switchbot')).SwitchBot;
+      queueScheduler.schedule(() => (switchbot = new SwitchBot()));
     } catch (e: any) {
       switchbot = false;
       this.errorLog(`Was 'node-switchbot' found: ${switchbot}, Error: ${e}`);


### PR DESCRIPTION
## :recycle: Current situation

```
[SwitchBot] Was 'node-switchbot' found: false, Error: TypeError: SwitchBot is not a constructor
[SwitchBot] Curtain: Curtain wasn't able to establish BLE Connection, node-switchbot: false
```

## :bulb: Proposed solution

Import the module correctly and stop unnecessarily importing `noble`. The latter was a workaround for what was fixed in https://github.com/OpenWonderLabs/node-switchbot/pull/221.

There are still issues with `node-switchbot` due to (at least) the static declaration of `getDeviceObject` which causes `this.noble` to be undefined:
https://github.com/OpenWonderLabs/node-switchbot/blob/7a8e59ce395cda608b2e5b4dbd571dac47d9f1b1/src/switchbot.ts#L263

Do you have any ideas @donavanbecker? Have any of these 3.x.x releases worked for you with BLE?