### PR TITLE
Remove unnecessary await keyword

### DIFF
--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -952,7 +952,7 @@ export class BlindTilt {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -974,7 +974,7 @@ export class BlindTilt {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -1168,7 +1168,7 @@ export class Bot {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -1190,7 +1190,7 @@ export class Bot {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/ceilinglight.ts
+++ b/src/device/ceilinglight.ts
@@ -882,7 +882,7 @@ export class CeilingLight {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -905,7 +905,7 @@ export class CeilingLight {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/colorbulb.ts
+++ b/src/device/colorbulb.ts
@@ -1070,7 +1070,7 @@ export class ColorBulb {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -1093,7 +1093,7 @@ export class ColorBulb {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/contact.ts
+++ b/src/device/contact.ts
@@ -490,7 +490,7 @@ export class Contact {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -512,7 +512,7 @@ export class Contact {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -972,7 +972,7 @@ export class Curtain {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -994,7 +994,7 @@ export class Curtain {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/humidifier.ts
+++ b/src/device/humidifier.ts
@@ -763,7 +763,7 @@ export class Humidifier {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.connected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -785,7 +785,7 @@ export class Humidifier {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/iosensor.ts
+++ b/src/device/iosensor.ts
@@ -531,7 +531,7 @@ export class IOSensor {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -553,7 +553,7 @@ export class IOSensor {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/lightstrip.ts
+++ b/src/device/lightstrip.ts
@@ -907,7 +907,7 @@ export class StripLight {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -930,7 +930,7 @@ export class StripLight {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/lock.ts
+++ b/src/device/lock.ts
@@ -643,7 +643,7 @@ export class Lock {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -665,7 +665,7 @@ export class Lock {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/meter.ts
+++ b/src/device/meter.ts
@@ -524,7 +524,7 @@ export class Meter {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -546,7 +546,7 @@ export class Meter {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/meterplus.ts
+++ b/src/device/meterplus.ts
@@ -529,7 +529,7 @@ export class MeterPlus {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -551,7 +551,7 @@ export class MeterPlus {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/motion.ts
+++ b/src/device/motion.ts
@@ -434,7 +434,7 @@ export class Motion {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -456,7 +456,7 @@ export class Motion {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/plug.ts
+++ b/src/device/plug.ts
@@ -454,7 +454,7 @@ export class Plug {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -484,7 +484,7 @@ export class Plug {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }

--- a/src/device/robotvacuumcleaner.ts
+++ b/src/device/robotvacuumcleaner.ts
@@ -616,7 +616,7 @@ export class RobotVacuumCleaner {
   }
 
   async stopScanning(switchbot: any) {
-    await switchbot.stopScan();
+    switchbot.stopScan();
     if (this.BLE_IsConnected) {
       await this.BLEparseStatus();
       await this.updateHomeKitCharacteristics();
@@ -646,7 +646,7 @@ export class RobotVacuumCleaner {
         };
         await sleep(10000);
         // Stop to monitor
-        await switchbot.stopScan();
+        switchbot.stopScan();
       })();
     }
   }


### PR DESCRIPTION
## :recycle: Current situation

The `stopScan` method is called with `await` but it does not return a promise:
https://github.com/dnicolson/node-switchbot/blob/3877620/src/switchbot.ts#L493

## :bulb: Proposed solution

Remove the `await` keyword, alternatively in `node-switchbot` it might be possible to use the noble `stopScanningAsync` method instead of `stopScanning`.
