### PR TITLE
Fix a bug where Switchbot Curtain 3 models would fail to update over BLE

### DIFF
--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -624,7 +624,7 @@ export class Curtain extends deviceBase {
       this.debugLog(`${this.accessory.displayName} Mode: ${Mode}`);
       if (switchbot !== false) {
         try {
-          const device_list = await switchbot.discover({ model: 'c', quick: true, id: this.device.bleMac });
+          const device_list = await switchbot.discover({ model: this.device.bleModel, quick: true, id: this.device.bleMac });
           this.infoLog(`${this.accessory.displayName} Target Position: ${this.WindowCovering.TargetPosition}`);
 
           await this.retryBLE({


### PR DESCRIPTION
## :recycle: Current situation

A hardcoded value in the code meant that Switchbot Curtain 3 models would always fail to update their state if a BLEPush was triggered in the code

## :bulb: Proposed solution

Use the device's BLE model instead of a hardcoded value

## :gear: Release Notes

N/A

## :heavy_plus_sign: Additional Information
N/A

### Testing

No tests added, but manually tested with real world device and it does seem to be working correctly now.

### Reviewer Nudging

N/A simple one line change.
