### PR TITLE
Fix temperate bug #1024

### DIFF
--- a/src/device/iosensor.ts
+++ b/src/device/iosensor.ts
@@ -180,7 +180,7 @@ export class IOSensor extends deviceBase {
 
   async BLEparseStatus(): Promise<void> {
     await this.debugLog('BLEparseStatus')
-    await this.debugLog(`(battery, temperature, humidity) = BLE:(${this.serviceData.battery}, ${this.serviceData.celcius}, ${this.serviceData.humidity}), current:(${this.Battery.BatteryLevel}, ${this.TemperatureSensor?.CurrentTemperature}, ${this.HumiditySensor?.CurrentRelativeHumidity})`)
+    await this.debugLog(`(battery, temperature, humidity) = BLE:(${this.serviceData.battery}, ${this.serviceData.celsius}, ${this.serviceData.humidity}), current:(${this.Battery.BatteryLevel}, ${this.TemperatureSensor?.CurrentTemperature}, ${this.HumiditySensor?.CurrentRelativeHumidity})`)
 
     // BatteryLevel
     this.Battery.BatteryLevel = this.serviceData.battery
@@ -200,7 +200,7 @@ export class IOSensor extends deviceBase {
 
     // Current Temperature
     if (!this.device.meter?.hide_temperature && this.TemperatureSensor?.Service) {
-      const CELSIUS = this.serviceData.celcius < 0 ? 0 : this.serviceData.celcius > 100 ? 100 : this.serviceData.celcius
+      const CELSIUS = this.serviceData.celsius < 0 ? 0 : this.serviceData.celsius > 100 ? 100 : this.serviceData.celsius
       this.TemperatureSensor.CurrentTemperature = CELSIUS
       await this.debugLog(`Temperature: ${this.TemperatureSensor.CurrentTemperature}°c`)
     }

--- a/src/types/bledevicestatus.ts
+++ b/src/types/bledevicestatus.ts
@@ -162,7 +162,7 @@ export type outdoorMeterServiceData = serviceData & {
   model: SwitchBotBLEModel.OutdoorMeter
   modelName: SwitchBotBLEModelName.OutdoorMeter
   modelFriendlyName: SwitchBotBLEModelFriendlyName.OutdoorMeter
-  celcius: number
+  celsius: number
   fahrenheit: number
   fahrenheit_mode: boolean
   humidity: number


### PR DESCRIPTION
## :recycle: Current situation

*Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets).*

I have a SwitchBot indoor/outdoor thermo-hygrometer. Battery level and humidity are read correctly and displayed in the Apple Home app. The temperature also seems to be read correctly at first according to the debug logs, but then for some reason it is converted (?) to undefined and displayed as 30 °C (default init value?) in the Apple Home app.

```

[9/19/2024, 1:28:12 AM] [SwitchBot] [DEBUG] WoIOSensor: ThermometerKuehlschrank {
  "id": "XXXXXXXXXXXX",
  "address": "xx:xx:xx:xx:xx:xx",
  "rssi": -84,
  "serviceData": {
    "model": "w",
    "modelName": "WoIOSensorTH",
    "modelFriendlyName": "Outdoor Meter",
    "temperature": {
      "c": 6.7,
      "f": 44.1
    },
    "celsius": 6.7,
    "fahrenheit": 44.1,
    "fahrenheit_mode": true,
    "humidity": 80,
    "battery": 88
  }
}
[9/19/2024, 1:28:12 AM] [SwitchBot] [DEBUG] WoIOSensor: ThermometerKuehlschrank address: xx:xx:xx:xx:xx:xx, model: w
[9/19/2024, 1:28:12 AM] [SwitchBot] [DEBUG] WoIOSensor: ThermometerKuehlschrank serviceData: {"model":"w","modelName":"WoIOSensorTH","modelFriendlyName":"Outdoor Meter","temperature":{"c":6.7,"f":44.1},"celsius":6.7,"fahrenheit":44.1,"fahrenheit_mode":true,"humidity":80,"battery":88}
[9/19/2024, 1:28:15 AM] [SwitchBot] [DEBUG] WoIOSensor: ThermometerKuehlschrank BLEparseStatus
[9/19/2024, 1:28:15 AM] [SwitchBot] [DEBUG] WoIOSensor: ThermometerKuehlschrank (battery, temperature, humidity) = BLE:(88, undefined, 80), current:(88, 30, 80)
[9/19/2024, 1:28:15 AM] [SwitchBot] [DEBUG] WoIOSensor: ThermometerKuehlschrank BatteryLevel: 88
[9/19/2024, 1:28:15 AM] [SwitchBot] [DEBUG] WoIOSensor: ThermometerKuehlschrank StatusLowBattery: 0
[9/19/2024, 1:28:15 AM] [SwitchBot] [DEBUG] WoIOSensor: ThermometerKuehlschrank CurrentRelativeHumidity: 80%
[9/19/2024, 1:28:15 AM] [SwitchBot] [DEBUG] WoIOSensor: ThermometerKuehlschrank Temperature: undefinedÂ°c
```

## :bulb: Proposed solution

*Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?*

If you look into `src/device/iosensor.ts`, the function `BLEparseStatus()` tries to access `this.serviceData.celcius` (with a **C** -> celCius). However, as you can see in the debug logs above, it should be called `this.serviceData.celsius` (with an **S** -> celSius). This seems to be a typo.

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

This update fixes an issue with the temperature reading from SwitchBot indoor/outdoor thermo-hygrometers. The typo in the code that caused the temperature to display incorrectly in the Apple Home app has been corrected. Users should now see the correct temperature readings without any further configuration.

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

This fix addresses a minor typo in the codebase that had significant impact on the temperature reading functionality. No additional configurations or settings are required from the user's side.

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

No new tests were added or changed. The existing functionality has been corrected to ensure proper temperature readings.

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*

The reviewer should start by looking at the changes in `src/device/iosensor.ts`, specifically the `BLEparseStatus()` function. Verifying the correct spelling of celsius should be the main focus. Additionally, running the existing test cases to ensure no regressions have been introduced would be beneficial.