### PR TITLE
Fix #1065 - light level stuck at max

### DIFF
--- a/src/device/device.ts
+++ b/src/device/device.ts
@@ -221,7 +221,7 @@ export abstract class deviceBase {
     this.debugLog(`LightLevel: ${lightLevel}, set_minLux: ${set_minLux}, set_maxLux: ${set_maxLux}, spaceBetweenLevels: ${spaceBetweenLevels}, numberOfLevels: ${numberOfLevels}`)
     const CurrentAmbientLightLevel = lightLevel === 1
       ? set_minLux
-      : lightLevel = numberOfLevels
+      : lightLevel === numberOfLevels
         ? set_maxLux
         : ((set_maxLux - set_minLux) / spaceBetweenLevels) * (Number(lightLevel) - 1)
     await this.debugLog(`CurrentAmbientLightLevel: ${CurrentAmbientLightLevel}, LightLevel: ${lightLevel}, set_minLux: ${set_minLux}, set_maxLux: ${set_maxLux}`)


### PR DESCRIPTION
fix light level report, which was stuck at max due to the inappropriate assignment operator.

## :recycle: Current situation

See #1065 - ambient light level reported to HomeKit is stuck at 6000 lux despite light level report being accurate. Debugging revealed an accidental assignment operator ("=") where a comparison ("===") was required.

## :bulb: Proposed solution

This PR contains a one-line patch to fix the above.

## :gear: Release Notes

No change required.

### Testing

Not aware of any relevant tests

### Reviewer Nudging

Observe the ambient light level of a connected hub 2 in home bridge UI before and after the patch.