### PR TITLE
Fix max retry

### DIFF
--- a/src/device/device.ts
+++ b/src/device/device.ts
@@ -130,7 +130,7 @@ export abstract class deviceBase {
   }
 
   async maxRetryBLE(): Promise<number> {
-    return this.device.maxRetry ? this.device.maxRetry : 5
+    return this.device.maxRetry !== undefined ? this.device.maxRetry : 5
   }
 
   async getDeviceScanDuration(accessory: PlatformAccessory, device: device & devicesConfig): Promise<void> {


### PR DESCRIPTION
## :recycle: Current situation

The value `0` cannot be used as it is evaluated in the same way as being unset.

## :bulb: Proposed solution

Check the actual type of the value to allow 0 retries.

This is needed with v4.0.0+ as `READ_TIMEOUT` errors occur even on success, resulting in erratic retry behavior. Using v.3.7.0 is still the safest option.