### PR TITLE
Fix light level

### DIFF
--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -347,7 +347,7 @@ export class BlindTilt extends deviceBase {
       const set_maxLux = (this.device as blindTiltConfig).set_maxLux ?? 6001
       const spaceBetweenLevels = 9
 
-      await this.getLightLevel(this.serviceData.lightLevel, set_minLux, set_maxLux, spaceBetweenLevels)
+      this.getLightLevel(this.serviceData.lightLevel, set_minLux, set_maxLux, spaceBetweenLevels)
       this.debugLog(`LightLevel: ${this.serviceData.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor!.CurrentAmbientLightLevel}`)
     }
 
@@ -378,7 +378,7 @@ export class BlindTilt extends deviceBase {
       const set_minLux = (this.device as blindTiltConfig).set_minLux ?? 1
       const set_maxLux = (this.device as blindTiltConfig).set_maxLux ?? 6001
       const lightLevel = this.deviceStatus.lightLevel === 'bright' ? set_maxLux : set_minLux
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
       this.debugLog(`LightLevel: ${this.deviceStatus.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
 

--- a/src/device/contact.ts
+++ b/src/device/contact.ts
@@ -201,7 +201,7 @@ export class Contact extends deviceBase {
       const set_minLux = (this.device as contactConfig).set_minLux ?? 1
       const set_maxLux = (this.device as contactConfig).set_maxLux ?? 6001
       const lightLevel = this.serviceData.lightLevel === 'bright' ? set_maxLux : set_minLux
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
       this.debugLog(`LightLevel: ${this.serviceData.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
     // BatteryLevel
@@ -230,7 +230,7 @@ export class Contact extends deviceBase {
       const set_minLux = (this.device as contactConfig).set_minLux ?? 1
       const set_maxLux = (this.device as contactConfig).set_maxLux ?? 6001
       const lightLevel = this.deviceStatus.brightness === 'bright' ? set_maxLux : set_minLux
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
       this.debugLog(`LightLevel: ${this.deviceStatus.brightness}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
     // BatteryLevel
@@ -272,7 +272,7 @@ export class Contact extends deviceBase {
       const set_minLux = (this.device as contactConfig).set_minLux ?? 1
       const set_maxLux = (this.device as contactConfig).set_maxLux ?? 6001
       const lightLevel = this.webhookContext.brightness === 'bright' ? set_maxLux : set_minLux
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
       this.debugLog(`LightLevel: ${this.webhookContext.brightness}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
   }

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -386,7 +386,7 @@ export class Curtain extends deviceBase {
       const set_minLux = (this.device as curtainConfig).set_minLux ?? 1
       const set_maxLux = (this.device as curtainConfig).set_maxLux ?? 6001
       const lightLevel = this.serviceData.lightLevel
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(lightLevel, set_minLux, set_maxLux, 19)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(lightLevel, set_minLux, set_maxLux, 19)
       this.debugLog(`LightLevel: ${this.serviceData.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
     // BatteryLevel
@@ -411,7 +411,7 @@ export class Curtain extends deviceBase {
       const set_minLux = (this.device as curtainConfig).set_minLux ?? 1
       const set_maxLux = (this.device as curtainConfig).set_maxLux ?? 6001
       const lightLevel = this.deviceStatus.lightLevel === 'bright' ? set_maxLux : set_minLux
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
       this.debugLog(`CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
 

--- a/src/device/device.ts
+++ b/src/device/device.ts
@@ -253,7 +253,10 @@ export abstract class deviceBase {
    * @param spaceBetweenLevels number
    * @returns CurrentAmbientLightLevel
    */
-  async getLightLevel(lightLevel: number, set_minLux: number, set_maxLux: number, spaceBetweenLevels: number): Promise<number> {
+  getLightLevel(lightLevel: number, set_minLux: number, set_maxLux: number, spaceBetweenLevels: number): number {
+    if (lightLevel === 0) {
+      return 0.0001
+    }
     const numberOfLevels = spaceBetweenLevels + 1
     this.debugLog(`LightLevel: ${lightLevel}, set_minLux: ${set_minLux}, set_maxLux: ${set_maxLux}, spaceBetweenLevels: ${spaceBetweenLevels}, numberOfLevels: ${numberOfLevels}`)
     const CurrentAmbientLightLevel = lightLevel === 1

--- a/src/device/hub.ts
+++ b/src/device/hub.ts
@@ -194,7 +194,7 @@ export class Hub extends deviceBase {
       const set_minLux = (this.device as hubConfig).set_minLux ?? 1
       const set_maxLux = (this.device as hubConfig).set_maxLux ?? 6001
       const lightLevel = this.serviceData.lightLevel
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(lightLevel, set_minLux, set_maxLux, 19)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(lightLevel, set_minLux, set_maxLux, 19)
       this.debugLog(`LightLevel: ${this.serviceData.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
   }
@@ -220,7 +220,7 @@ export class Hub extends deviceBase {
       const set_minLux = (this.device as hubConfig).set_minLux ?? 1
       const set_maxLux = (this.device as hubConfig).set_maxLux ?? 6001
       const lightLevel = this.deviceStatus.lightLevel
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(lightLevel, set_minLux, set_maxLux, 19)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(lightLevel, set_minLux, set_maxLux, 19)
       this.debugLog(`LightLevel: ${this.deviceStatus.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor!.CurrentAmbientLightLevel}`)
     }
 
@@ -264,7 +264,7 @@ export class Hub extends deviceBase {
     if (!(this.device as hubConfig).hide_lightsensor && this.LightSensor?.Service) {
       const set_minLux = (this.device as hubConfig).set_minLux ?? 1
       const set_maxLux = (this.device as hubConfig).set_maxLux ?? 6001
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(this.webhookContext.lightLevel, set_minLux, set_maxLux, 19)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(this.webhookContext.lightLevel, set_minLux, set_maxLux, 19)
       this.debugLog(`CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
   }

--- a/src/device/motion.ts
+++ b/src/device/motion.ts
@@ -168,7 +168,7 @@ export class Motion extends deviceBase {
       const set_minLux = (this.device as motionConfig).set_minLux ?? 1
       const set_maxLux = (this.device as motionConfig).set_maxLux ?? 6001
       const lightLevel = this.serviceData.lightLevel === 'bright' ? set_maxLux : set_minLux
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
       this.debugLog(`LightLevel: ${this.serviceData.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
 
@@ -196,7 +196,7 @@ export class Motion extends deviceBase {
       const set_minLux = (this.device as motionConfig).set_minLux ?? 1
       const set_maxLux = (this.device as motionConfig).set_maxLux ?? 6001
       const lightLevel = this.deviceStatus.brightness === 'bright' ? set_maxLux : set_minLux
-      this.LightSensor.CurrentAmbientLightLevel = await this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
+      this.LightSensor.CurrentAmbientLightLevel = this.getLightLevel(lightLevel, set_minLux, set_maxLux, 2)
       this.debugLog(`LightLevel: ${this.deviceStatus.brightness}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
     // BatteryLevel


### PR DESCRIPTION
## ♻️ Current situation

When the light level is 0, this occurs:
```
This plugin generated a warning from the characteristic 'Current Ambient Light Level': characteristic was supplied illegal value: number -315.7894736842105 exceeded minimum of 0.0001. See https://homebridge.io/w/JtMGR for more info.
```

## :bulb: Proposed solution

*Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?*

It's not clear why the `spaceBetweenLevels` value is 19 for BLE and 2 for OpenAPI.