### PR TITLE
Fix service data check

### DIFF
--- a/src/device/blindtilt.ts
+++ b/src/device/blindtilt.ts
@@ -351,7 +351,7 @@ export class BlindTilt extends deviceBase {
       this.debugLog(`LightLevel: ${this.serviceData.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor!.CurrentAmbientLightLevel}`)
     }
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -282,7 +282,7 @@ export class Bot extends deviceBase {
     this.debugLog(`${mode} Mode, On: ${this.On}`)
     this.accessory.context.On = this.On
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/contact.ts
+++ b/src/device/contact.ts
@@ -205,7 +205,7 @@ export class Contact extends deviceBase {
       this.debugLog(`LightLevel: ${this.serviceData.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/curtain.ts
+++ b/src/device/curtain.ts
@@ -379,12 +379,12 @@ export class Curtain extends deviceBase {
     this.debugLog('BLEparseStatus')
     this.debugLog(`(position, battery) = BLE:(${this.serviceData.position}, ${this.serviceData.battery}), current:(${this.WindowCovering.CurrentPosition}, ${this.Battery.BatteryLevel})`)
     // CurrentPosition
-    if (this.serviceData.position) {
+    if ('position' in this.serviceData) {
       this.WindowCovering.CurrentPosition = 100 - this.serviceData.position
       await this.getCurrentPostion()
     }
     // CurrentAmbientLightLevel
-    if (!(this.device as curtainConfig).hide_lightsensor && this.LightSensor?.Service && this.serviceData.lightLevel) {
+    if (!(this.device as curtainConfig).hide_lightsensor && this.LightSensor?.Service && 'lightLevel' in this.serviceData) {
       const set_minLux = (this.device as curtainConfig).set_minLux ?? 1
       const set_maxLux = (this.device as curtainConfig).set_maxLux ?? 6001
       const lightLevel = this.serviceData.lightLevel
@@ -392,7 +392,7 @@ export class Curtain extends deviceBase {
       this.debugLog(`LightLevel: ${this.serviceData.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/iosensor.ts
+++ b/src/device/iosensor.ts
@@ -179,7 +179,7 @@ export class IOSensor extends deviceBase {
     this.debugLog('BLEparseStatus')
     this.debugLog(`(battery, temperature, humidity) = BLE:(${this.serviceData.battery}, ${this.serviceData.celsius}, ${this.serviceData.humidity}), current:(${this.Battery.BatteryLevel}, ${this.TemperatureSensor?.CurrentTemperature}, ${this.HumiditySensor?.CurrentRelativeHumidity})`)
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/lock.ts
+++ b/src/device/lock.ts
@@ -225,7 +225,7 @@ export class Lock extends deviceBase {
       this.debugLog(`ContactSensorState: ${this.ContactSensor.ContactSensorState}`)
     }
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/meter.ts
+++ b/src/device/meter.ts
@@ -185,7 +185,7 @@ export class Meter extends deviceBase {
       this.debugLog(`CurrentTemperature: ${this.TemperatureSensor.CurrentTemperature}°c`)
     }
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/meterplus.ts
+++ b/src/device/meterplus.ts
@@ -189,7 +189,7 @@ export class MeterPlus extends deviceBase {
       this.debugLog(`CurrentTemperature: ${this.TemperatureSensor.CurrentTemperature}°c`)
     }
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/meterpro.ts
+++ b/src/device/meterpro.ts
@@ -189,7 +189,7 @@ export class MeterPro extends deviceBase {
       this.debugLog(`CurrentTemperature: ${this.TemperatureSensor.CurrentTemperature}°c`)
     }
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/motion.ts
+++ b/src/device/motion.ts
@@ -172,7 +172,7 @@ export class Motion extends deviceBase {
       this.debugLog(`LightLevel: ${this.serviceData.lightLevel}, CurrentAmbientLightLevel: ${this.LightSensor.CurrentAmbientLightLevel}`)
     }
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/robotvacuumcleaner.ts
+++ b/src/device/robotvacuumcleaner.ts
@@ -171,7 +171,7 @@ export class RobotVacuumCleaner extends deviceBase {
     this.debugLog(`On: ${this.LightBulb.On}`)
 
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)

--- a/src/device/waterdetector.ts
+++ b/src/device/waterdetector.ts
@@ -159,7 +159,7 @@ export class WaterDetector extends deviceBase {
       this.debugLog(`LeakDetected: ${this.LeakSensor.LeakDetected}`)
     }
     // Battery Info
-    if (this.serviceData.battery) {
+    if ('battery' in this.serviceData) {
       // BatteryLevel
       this.Battery.BatteryLevel = this.serviceData.battery
       this.debugLog(`BatteryLevel: ${this.Battery.BatteryLevel}`)


### PR DESCRIPTION
## :recycle: Current situation

Falsy service data values are not used, this occurs when the curtain is at the closed position.

## :bulb: Proposed solution

Check for the service data key.
