### PR TITLE
fix: Improve debug log in BLE connection

### DIFF
--- a/src/device/device.ts
+++ b/src/device/device.ts
@@ -312,6 +312,7 @@ export abstract class deviceBase {
     // Set an event handler
     let serviceData = { model: this.device.bleModel, modelName: this.device.bleModelName } as ad['serviceData']
     switchbot.onadvertisement = (ad: ad) => {
+      this.debugLog(`ad: ${JSON.stringify(ad, null, '  ')}`)
       if (this.device.bleMac === ad.address && ad.serviceData.model === this.device.bleModel) {
         this.debugLog(`${JSON.stringify(ad, null, '  ')}`)
         this.debugLog(`address: ${ad.address}, model: ${ad.serviceData.model}`)

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2630,7 +2630,7 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
   async connectBLE(accessory: PlatformAccessory, device: device & devicesConfig): Promise<any> {
     try {
       queueScheduler.schedule(async () => this.switchBotBLE)
-      this.debugLog(`${device.deviceType}: ${accessory.displayName} 'node-switchbot' found: ${JSON.stringify(this.switchBotBLE)}`)
+      this.debugLog(`${device.deviceType}: ${accessory.displayName} 'node-switchbot' found: ${JSON.stringify(this.switchBotBLE, null, '  ')}`)
       return this.switchBotBLE
     } catch (e: any) {
       this.errorLog(`${device.deviceType}: ${accessory.displayName} 'node-switchbot' not found, Error: ${e.message ?? e}`)

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -2630,7 +2630,7 @@ export class SwitchBotPlatform implements DynamicPlatformPlugin {
   async connectBLE(accessory: PlatformAccessory, device: device & devicesConfig): Promise<any> {
     try {
       queueScheduler.schedule(async () => this.switchBotBLE)
-      this.debugLog(`${device.deviceType}: ${accessory.displayName} 'node-switchbot' found: ${this.switchBotBLE}`)
+      this.debugLog(`${device.deviceType}: ${accessory.displayName} 'node-switchbot' found: ${JSON.stringify(this.switchBotBLE)}`)
       return this.switchBotBLE
     } catch (e: any) {
       this.errorLog(`${device.deviceType}: ${accessory.displayName} 'node-switchbot' not found, Error: ${e.message ?? e}`)


### PR DESCRIPTION
## :recycle: Current situation

I have a slight problem with the log of the connectBLE function (in platform.ts). The `this.switchBotBLE` object is wrapped in a template literal in JS, so the output of that log is `[object Object]`. 

![image](https://github.com/user-attachments/assets/80b741a6-bc3c-4e4c-8d6f-5540b113fa66)

## :bulb: Proposed solution

 Wrap the `this.switchBotBLE` object in 'JSON.stringify' to inspect it in more detail