### PR TITLE
Update meterpro.ts

### DIFF
--- a/src/device/meterpro.ts
+++ b/src/device/meterpro.ts
@@ -369,7 +369,8 @@ export class MeterPro extends deviceBase {
         // Start to monitor advertisement packets
         const serviceData = await this.monitorAdvertisementPackets(switchBotBLE) as meterProServiceData | meterProCO2ServiceData
         // Update HomeKit
-        if (serviceData.model === SwitchBotBLEModel.MeterPro && serviceData.modelName === SwitchBotBLEModelName.MeterPro) {
+        if ((serviceData.model === SwitchBotBLEModel.MeterPro && serviceData.modelName === SwitchBotBLEModelName.MeterPro) || 
+            (serviceData.model === SwitchBotBLEModel.MeterProCO2 && serviceData.modelName === SwitchBotBLEModelName.MeterProCO2)) {
           this.serviceData = serviceData
           if (serviceData !== undefined || serviceData !== null) {
             await this.BLEparseStatus()


### PR DESCRIPTION
## :recycle: Current situation

*Describe the current situation. Explain current problems, if there are any. Be as descriptive as possible (e.g., including examples or code snippets).*

- doesn't support the `Meter Pro C02` fully (just missing if condition)

logs:
```
[7/28/2025, 10:27:43 PM] [SwitchBot] [DEBUG] [parseAdvertising.b0e9fe55326d.5] return {"id":"b0e9fe55326d","address":"b0:e9:fe:55:32:6d","rssi":-50,"serviceData":{"model":"5","modelName":"WoSensorTHPc","modelFriendlyName":"Meter Pro CO2","celsius":26.5,"fahrenheit":79.7,"fahrenheit_mode":false,"humidity":56,"battery":100,"co2":738}}
[7/28/2025, 10:27:43 PM] [SwitchBot] [DEBUG] MeterPro(CO2): Meter Pro ad: {
  "id": "b0e9fe55326d",
  "address": "b0:e9:fe:55:32:6d",
  "rssi": -50,
  "serviceData": {
    "model": "5",
    "modelName": "WoSensorTHPc",
    "modelFriendlyName": "Meter Pro CO2",
    "celsius": 26.5,
    "fahrenheit": 79.7,
    "fahrenheit_mode": false,
    "humidity": 56,
    "battery": 100,
    "co2": 738
  }
}
[7/28/2025, 10:27:43 PM] [SwitchBot] [DEBUG] MeterPro(CO2): Meter Pro {
  "id": "b0e9fe55326d",
  "address": "b0:e9:fe:55:32:6d",
  "rssi": -50,
  "serviceData": {
    "model": "5",
    "modelName": "WoSensorTHPc",
    "modelFriendlyName": "Meter Pro CO2",
    "celsius": 26.5,
    "fahrenheit": 79.7,
    "fahrenheit_mode": false,
    "humidity": 56,
    "battery": 100,
    "co2": 738
  }
}
[7/28/2025, 10:27:43 PM] [SwitchBot] [DEBUG] MeterPro(CO2): Meter Pro address: b0:e9:fe:55:32:6d, model: 5
[7/28/2025, 10:27:43 PM] [SwitchBot] [DEBUG] MeterPro(CO2): Meter Pro serviceData: {"model":"5","modelName":"WoSensorTHPc","modelFriendlyName":"Meter Pro CO2","celsius":26.5,"fahrenheit":79.7,"fahrenheit_mode":false,"humidity":56,"battery":100,"co2":738}
[7/28/2025, 10:27:43 PM] [SwitchBot] [DEBUG] Stopped Scanning for SwitchBot BLE devices.
[7/28/2025, 10:27:43 PM] [SwitchBot] MeterPro(CO2): Meter Pro failed to get serviceData, serviceData: {"model":"5","modelName":"WoSensorTHPc","modelFriendlyName":"Meter Pro CO2","celsius":26.5,"fahrenheit":79.7,"fahrenheit_mode":false,"humidity":56,"battery":100,"co2":738}
[7/28/2025, 10:27:43 PM] [SwitchBot] MeterPro(CO2): Meter Pro wasn't able to establish BLE Connection, node-switchbot: [object Object]
```

## :bulb: Proposed solution

*Describe the proposed solution and changes. How does it affect the project? How does it affect the internal structure (e.g., refactorings)?*

- adding if condition 

## :gear: Release Notes

*Provide a summary of the changes or features from a user's point of view. If there are breaking changes, provide migration guides using code examples of the affected features.*

## :heavy_plus_sign: Additional Information
*If applicable, provide additional context in this section.*

### Testing

*Which tests were added? Which existing tests were adapted/changed? Which situations are covered, and what edge cases are missing?*

- it's sending the received data to homekit ✅

### Reviewer Nudging

*Where should the reviewer start? what is a good entry point?*

- fixing https://github.com/OpenWonderLabs/homebridge-switchbot/issues/1164
