### PR TITLE
 feat(bot): add BLE password command support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [4.3.11](https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v4.3.10...v4.3.11) (2026-02-17)
 
-- Added BLE password support for SwitchBot Bot using encrypted BLE commands.
-- Added per-device Bot `password` config in `options.devices[]` (BLE/BLE+OpenAPI connections).
-- Added tests for Bot BLE password validation and encrypted command generation.
 
 
 ## [4.3.10](https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v4.3.9...v4.3.10) (2026-02-10)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file. This projec
 
 ## [4.3.11](https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v4.3.10...v4.3.11) (2026-02-17)
 
+- Added BLE password support for SwitchBot Bot using encrypted BLE commands.
+- Added per-device Bot `password` config in `options.devices[]` (BLE/BLE+OpenAPI connections).
+- Added tests for Bot BLE password validation and encrypted command generation.
 
 
 ## [4.3.10](https://github.com/OpenWonderLabs/homebridge-switchbot/compare/v4.3.9...v4.3.10) (2026-02-10)

--- a/README.md
+++ b/README.md
@@ -168,6 +168,8 @@
   - If using Bluetooth Low Energy (BLE) only:
     - Must supply `deviceId` & `deviceName` to Device Config
     - Check `Enable Bluetooth Low Energy (BLE) Connection` on Device Config
+    - If your Bot has an app password enabled, set `password` in that device's config.
+      - Password must be exactly 4 letters/numbers and is case-sensitive.
 - [SwitchBot Hub 2](https://us.switch-bot.com/products/switchbot-hub-2)
   - Supports OpenAPI & Bluetooth Low Energy (BLE) Connections
     - Enables Humidity, Temperature, and Light Sensor

--- a/config.schema.json
+++ b/config.schema.json
@@ -538,6 +538,15 @@
                     "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Bot' && model.options.devices[arrayIndices].deviceId);"
                   }
                 },
+                "password": {
+                  "title": "Bot BLE Password",
+                  "type": "string",
+                  "placeholder": "A1b2",
+                  "description": "Bot password set in SwitchBot app. Must be exactly 4 letters/numbers and is case-sensitive.",
+                  "condition": {
+                    "functionBody": "return (model.options && model.options.devices && !model.options.devices[arrayIndices].hide_device && model.options.devices[arrayIndices].configDeviceType === 'Bot' && model.options.devices[arrayIndices].deviceId && (model.options.devices[arrayIndices].connectionType === 'BLE' || model.options.devices[arrayIndices].connectionType === 'BLE/OpenAPI'));"
+                  }
+                },
                 "mapping": {
                   "title": "Mapping Mode",
                   "type": "string",
@@ -14241,6 +14250,7 @@
             "options.devices[].webhook",
             "options.devices[].type",
             "options.devices[].mode",
+            "options.devices[].password",
             "options.devices[].mapping",
             "options.devices[].allowPush",
             "options.devices[].doublePress",

--- a/src/device/bot.ble-password.test.ts
+++ b/src/device/bot.ble-password.test.ts
@@ -1,0 +1,67 @@
+import { Buffer } from 'node:buffer'
+
+import type { WoHand } from 'node-switchbot'
+import { describe, expect, it, vi } from 'vitest'
+
+import { executeBotBleAction } from './bot.js'
+
+describe('executeBotBleAction', () => {
+  it('uses legacy press/turnOn/turnOff methods when no password is configured', async () => {
+    const device = {
+      press: vi.fn().mockResolvedValue(undefined),
+      turnOn: vi.fn().mockResolvedValue(undefined),
+      turnOff: vi.fn().mockResolvedValue(undefined),
+      command: vi.fn(),
+    }
+    const botDevice = device as unknown as WoHand
+
+    await executeBotBleAction(botDevice, 0x00)
+    await executeBotBleAction(botDevice, 0x01)
+    await executeBotBleAction(botDevice, 0x02)
+
+    expect(device.press).toHaveBeenCalledOnce()
+    expect(device.turnOn).toHaveBeenCalledOnce()
+    expect(device.turnOff).toHaveBeenCalledOnce()
+    expect(device.command).not.toHaveBeenCalled()
+  })
+
+  it('uses encrypted command path when password is configured', async () => {
+    const device = {
+      press: vi.fn().mockResolvedValue(undefined),
+      turnOn: vi.fn().mockResolvedValue(undefined),
+      turnOff: vi.fn().mockResolvedValue(undefined),
+      command: vi.fn().mockResolvedValue(Buffer.from([0x01, 0x00, 0x00])),
+    }
+    const botDevice = device as unknown as WoHand
+
+    await executeBotBleAction(botDevice, 0x01, 'A1b2')
+
+    expect(device.command).toHaveBeenCalledOnce()
+    expect(device.command).toHaveBeenCalledWith(Buffer.from([0x57, 0x11, 0xB8, 0x59, 0x37, 0x46, 0x01]))
+    expect(device.turnOn).not.toHaveBeenCalled()
+  })
+
+  it('throws on invalid password', async () => {
+    const device = {
+      press: vi.fn().mockResolvedValue(undefined),
+      turnOn: vi.fn().mockResolvedValue(undefined),
+      turnOff: vi.fn().mockResolvedValue(undefined),
+      command: vi.fn().mockResolvedValue(Buffer.from([0x01, 0x00, 0x00])),
+    }
+    const botDevice = device as unknown as WoHand
+
+    await expect(executeBotBleAction(botDevice, 0x00, 'abc')).rejects.toThrow('Invalid Bot password')
+  })
+
+  it('throws when encrypted command response is invalid', async () => {
+    const device = {
+      press: vi.fn().mockResolvedValue(undefined),
+      turnOn: vi.fn().mockResolvedValue(undefined),
+      turnOff: vi.fn().mockResolvedValue(undefined),
+      command: vi.fn().mockResolvedValue(Buffer.from([0x00, 0x00, 0x00])),
+    }
+    const botDevice = device as unknown as WoHand
+
+    await expect(executeBotBleAction(botDevice, 0x02, 'A1b2')).rejects.toThrow('The device returned an error')
+  })
+})

--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -13,8 +13,36 @@ import { debounceTime, interval, skipWhile, Subject, take, tap } from 'rxjs'
 
 import type { SwitchBotPlatform } from '../platform.js'
 import type { botConfig, devicesConfig } from '../settings.js'
-import { formatDeviceIdAsMac } from '../utils.js'
+import { buildBotBleCommand, formatDeviceIdAsMac, validateBotPassword } from '../utils.js'
 import { deviceBase } from './device.js'
+
+type BotBleAction = 0x00 | 0x01 | 0x02
+
+export async function executeBotBleAction(
+  device: WoHand,
+  action: BotBleAction,
+  password?: string,
+): Promise<void> {
+  if (!password) {
+    if (action === 0x00) {
+      await device.press()
+      return
+    }
+    if (action === 0x01) {
+      await device.turnOn()
+      return
+    }
+    await device.turnOff()
+    return
+  }
+  validateBotPassword(password)
+  const reqBuf = buildBotBleCommand(action, password)
+  const resBuf = await device.command(reqBuf)
+  const code = resBuf.readUInt8(0)
+  if (resBuf.length !== 3 || (code !== 0x01 && code !== 0x05)) {
+    throw new Error(`The device returned an error: 0x${resBuf.toString('hex')}`)
+  }
+}
 
 /**
  * Platform Accessory
@@ -501,6 +529,15 @@ export class Bot extends deviceBase {
     if ((this.On !== this.accessory.context.On) || this.allowPush) {
       this.debugLog(`BLEpushChanges On: ${this.On} OnCached: ${this.accessory.context.On}`)
       const switchBotBLE = this.platform.switchBotBLE
+      const botPassword = (this.device as botConfig).password
+      if (botPassword) {
+        try {
+          validateBotPassword(botPassword)
+        } catch (e: any) {
+          this.errorLog(`Invalid Bot password config for ${this.device.deviceId}: ${e.message ?? e}`)
+          return
+        }
+      }
       try {
         const formattedDeviceId = formatDeviceIdAsMac(this.device.deviceId)
         this.device.bleMac = formattedDeviceId
@@ -513,7 +550,10 @@ export class Bot extends deviceBase {
             .then(async (device_list: SwitchbotDevice[]) => {
               const deviceList = device_list as WoHand[]
               this.infoLog(`On: ${this.On}`)
-              return await deviceList[0].press()
+              if (deviceList.length === 0) {
+                throw new Error('No device found')
+              }
+              return await executeBotBleAction(deviceList[0], 0x00, botPassword)
             })
             .then(async () => {
               this.successLog(`On: ${this.On} sent over SwitchBot BLE, sent successfully`)
@@ -526,6 +566,9 @@ export class Bot extends deviceBase {
             })
             .catch(async (e: any) => {
               await this.apiError(e)
+              if (botPassword) {
+                this.errorLog(`Bot BLE password command failed for ${this.device.deviceId}. Verify password and BLE response.`)
+              }
               this.errorLog(`failed BLEpushChanges with ${this.device.connectionType} Connection, Error Message: ${JSON.stringify(e.message)}`)
               await this.BLEPushConnection()
             })
@@ -541,9 +584,9 @@ export class Bot extends deviceBase {
                 fn: async () => {
                   if (deviceList.length > 0) {
                     if (this.On) {
-                      return await deviceList[0].turnOn()
+                      return await executeBotBleAction(deviceList[0], 0x01, botPassword)
                     } else {
-                      return await deviceList[0].turnOff()
+                      return await executeBotBleAction(deviceList[0], 0x02, botPassword)
                     }
                   } else {
                     throw new Error('No device found')
@@ -557,6 +600,9 @@ export class Bot extends deviceBase {
             })
             .catch(async (e: any) => {
               await this.apiError(e)
+              if (botPassword) {
+                this.errorLog(`Bot BLE password command failed for ${this.device.deviceId}. Verify password and BLE response.`)
+              }
               this.errorLog(`failed BLEpushChanges with ${this.device.connectionType} Connection, Error Message: ${JSON.stringify(e.message)}`)
               await this.BLEPushConnection()
             })

--- a/src/device/bot.ts
+++ b/src/device/bot.ts
@@ -3,12 +3,12 @@
  * bot.ts: @switchbot/homebridge-switchbot.
  */
 import type { CharacteristicValue, PlatformAccessory, Service } from 'homebridge'
-import type { bodyChange, botServiceData, botStatus, botWebhookContext, device, SwitchBotBLE, SwitchbotDevice, WoHand } from 'node-switchbot'
+import type { bodyChange, botServiceData, botStatus, botWebhookContext, device, SwitchBotBLE } from 'node-switchbot'
 /*
 * For Testing Locally:
 * import { SwitchBotBLEModel, SwitchBotBLEModelName } from '/Users/Shared/GitHub/OpenWonderLabs/node-switchbot/dist/index.js';
 */
-import { SwitchBotBLEModel, SwitchBotBLEModelName } from 'node-switchbot'
+import { SwitchBotBLEModel, SwitchBotBLEModelName, WoHand } from 'node-switchbot'
 import { debounceTime, interval, skipWhile, Subject, take, tap } from 'rxjs'
 
 import type { SwitchBotPlatform } from '../platform.js'
@@ -17,6 +17,76 @@ import { buildBotBleCommand, formatDeviceIdAsMac, validateBotPassword } from '..
 import { deviceBase } from './device.js'
 
 type BotBleAction = 0x00 | 0x01 | 0x02
+
+function normalizeBleAddress(address: string): string {
+  return address.toLowerCase().replace(/[^a-z0-9]/g, '')
+}
+
+function isDiscoveryTimeoutError(error: unknown): boolean {
+  const message = `${(error as any)?.message ?? error}`.toLowerCase()
+  return message.includes('discovery timeout') || message.includes('no switchbot devices found')
+}
+
+async function discoverBotByAddress(
+  switchBotBLE: SwitchBotBLE,
+  bleMac: string,
+  durationMs: number,
+): Promise<WoHand> {
+  const noble = (switchBotBLE as any)?.noble
+  if (!noble) {
+    throw new Error('Noble BLE object is unavailable for address-based fallback discovery')
+  }
+
+  const targetAddress = normalizeBleAddress(bleMac)
+  const wasScanning = Boolean((noble as any).scanning)
+
+  return await new Promise<WoHand>((resolve, reject) => {
+    let settled = false
+    let timer: NodeJS.Timeout
+    let onDiscover: (peripheral: any) => void
+
+    const finish = async (error?: Error, device?: WoHand) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      noble.off('discover', onDiscover)
+      if (!wasScanning) {
+        try {
+          await noble.stopScanningAsync()
+        } catch {
+          // ignore stop scan errors in fallback cleanup path
+        }
+      }
+      if (error) {
+        reject(error)
+      } else if (device) {
+        resolve(device)
+      } else {
+        reject(new Error('Address-based fallback discovery ended without a result'))
+      }
+    }
+
+    timer = setTimeout(() => {
+      void finish(new Error(`No SwitchBot device found by address ${bleMac} after ${durationMs}ms`))
+    }, durationMs)
+
+    onDiscover = (peripheral: any) => {
+      const candidateAddress = normalizeBleAddress(peripheral?.address ?? peripheral?.id ?? '')
+      if (candidateAddress === targetAddress) {
+        void finish(undefined, new WoHand(peripheral, noble))
+      }
+    }
+
+    noble.on('discover', onDiscover)
+    if (!wasScanning) {
+      noble.startScanningAsync([], false).catch((e: unknown) => {
+        void finish(new Error(`Failed to start address-based fallback scan: ${(e as any)?.message ?? e}`))
+      })
+    }
+  })
+}
 
 export async function executeBotBleAction(
   device: WoHand,
@@ -524,12 +594,43 @@ export class Bot extends deviceBase {
       })
   }
 
+  private async discoverBotDeviceWithFallback(
+    switchBotBLE: SwitchBotBLE,
+    botPassword?: string,
+  ): Promise<WoHand> {
+    const bleMac = this.device.bleMac ?? formatDeviceIdAsMac(this.device.deviceId)
+    const discoveryDurationMs = Math.max(this.scanDuration * 1000, 5000)
+
+    if (botPassword) {
+      try {
+        return await discoverBotByAddress(switchBotBLE, bleMac, discoveryDurationMs)
+      } catch (e: any) {
+        this.warnLog(`Address-based Bot discovery failed for ${this.device.deviceId}: ${e.message ?? e}. Falling back to model discovery.`)
+      }
+    }
+
+    try {
+      const deviceList = await switchBotBLE.discover({ duration: discoveryDurationMs, model: this.device.bleModel, quick: true, id: bleMac }) as WoHand[]
+      if (deviceList.length === 0) {
+        throw new Error('No device found')
+      }
+      return deviceList[0]
+    } catch (e: any) {
+      if (botPassword && isDiscoveryTimeoutError(e)) {
+        this.warnLog(`Bot discovery by model timed out for ${this.device.deviceId}. Trying address-based fallback discovery.`)
+        return await discoverBotByAddress(switchBotBLE, bleMac, discoveryDurationMs)
+      }
+      throw e
+    }
+  }
+
   async BLEpushChanges(): Promise<void> {
     this.debugLog('BLEpushChanges')
     if ((this.On !== this.accessory.context.On) || this.allowPush) {
       this.debugLog(`BLEpushChanges On: ${this.On} OnCached: ${this.accessory.context.On}`)
       const switchBotBLE = this.platform.switchBotBLE
       const botPassword = (this.device as botConfig).password
+      const shouldPausePlatformScan = Boolean(botPassword && this.config.options?.BLE && !this.device.disablePlatformBLE)
       if (botPassword) {
         try {
           validateBotPassword(botPassword)
@@ -539,78 +640,84 @@ export class Bot extends deviceBase {
         }
       }
       try {
+        if (shouldPausePlatformScan) {
+          try {
+            await switchBotBLE.stopScan()
+            this.debugLog('Paused platform BLE scanning for password Bot command execution.')
+          } catch {
+            this.debugLog('Platform BLE scanning was not active or could not be paused.')
+          }
+        }
         const formattedDeviceId = formatDeviceIdAsMac(this.device.deviceId)
         this.device.bleMac = formattedDeviceId
         this.debugLog(`bleMac: ${this.device.bleMac}`)
         // if (switchBotBLE !== false) {
         this.debugLog(`Bot Mode: ${this.botMode}`)
         if (this.botMode === 'press') {
-          switchBotBLE
-            .discover({ model: this.device.bleModel, quick: true, id: this.device.bleMac })
-            .then(async (device_list: SwitchbotDevice[]) => {
-              const deviceList = device_list as WoHand[]
-              this.infoLog(`On: ${this.On}`)
-              if (deviceList.length === 0) {
-                throw new Error('No device found')
-              }
-              return await executeBotBleAction(deviceList[0], 0x00, botPassword)
-            })
-            .then(async () => {
-              this.successLog(`On: ${this.On} sent over SwitchBot BLE, sent successfully`)
+          try {
+            const botDevice = await this.discoverBotDeviceWithFallback(switchBotBLE, botPassword)
+            this.infoLog(`On: ${this.On}`)
+            await executeBotBleAction(botDevice, 0x00, botPassword)
+            this.successLog(`On: ${this.On} sent over SwitchBot BLE, sent successfully`)
+            await this.updateHomeKitCharacteristics()
+            setTimeout(async () => {
+              this.On = false
               await this.updateHomeKitCharacteristics()
-              setTimeout(async () => {
-                this.On = false
-                await this.updateHomeKitCharacteristics()
-                this.debugLog(`On: ${this.On}, Switch Timeout`)
-              }, 500)
-            })
-            .catch(async (e: any) => {
-              await this.apiError(e)
-              if (botPassword) {
-                this.errorLog(`Bot BLE password command failed for ${this.device.deviceId}. Verify password and BLE response.`)
-              }
-              this.errorLog(`failed BLEpushChanges with ${this.device.connectionType} Connection, Error Message: ${JSON.stringify(e.message)}`)
-              await this.BLEPushConnection()
-            })
+              this.debugLog(`On: ${this.On}, Switch Timeout`)
+            }, 500)
+          } catch (e: any) {
+            await this.apiError(e)
+            if (botPassword && !isDiscoveryTimeoutError(e)) {
+              this.errorLog(`Bot BLE password command failed for ${this.device.deviceId}. Verify password and BLE response.`)
+            }
+            if (isDiscoveryTimeoutError(e)) {
+              this.errorLog(`Bot BLE discovery failed for ${this.device.deviceId}. Device was not discovered before timeout.`)
+            }
+            this.errorLog(`failed BLEpushChanges with ${this.device.connectionType} Connection, Error Message: ${JSON.stringify(e.message)}`)
+            await this.BLEPushConnection()
+          }
         } else if (this.botMode === 'switch') {
-          switchBotBLE
-            .discover({ model: this.device.bleModel, quick: true, id: this.device.bleMac })
-            .then(async (device_list: SwitchbotDevice[]) => {
-              const deviceList = device_list as WoHand[]
-              this.infoLog(`On: ${this.On}`)
-              this.warnLog(`device_list: ${JSON.stringify(device_list)}`)
-              return await this.retryBLE({
-                max: this.maxRetryBLE(),
-                fn: async () => {
-                  if (deviceList.length > 0) {
-                    if (this.On) {
-                      return await executeBotBleAction(deviceList[0], 0x01, botPassword)
-                    } else {
-                      return await executeBotBleAction(deviceList[0], 0x02, botPassword)
-                    }
-                  } else {
-                    throw new Error('No device found')
-                  }
-                },
-              })
+          try {
+            const botDevice = await this.discoverBotDeviceWithFallback(switchBotBLE, botPassword)
+            this.infoLog(`On: ${this.On}`)
+            this.warnLog(`device: ${JSON.stringify({ id: botDevice.id, address: botDevice.address, model: botDevice.model })}`)
+            await this.retryBLE({
+              max: this.maxRetryBLE(),
+              fn: async () => {
+                if (this.On) {
+                  return await executeBotBleAction(botDevice, 0x01, botPassword)
+                } else {
+                  return await executeBotBleAction(botDevice, 0x02, botPassword)
+                }
+              },
             })
-            .then(async () => {
-              this.successLog(`On: ${this.On} sent over SwitchBot BLE, sent successfully`)
-              await this.updateHomeKitCharacteristics()
-            })
-            .catch(async (e: any) => {
-              await this.apiError(e)
-              if (botPassword) {
-                this.errorLog(`Bot BLE password command failed for ${this.device.deviceId}. Verify password and BLE response.`)
-              }
-              this.errorLog(`failed BLEpushChanges with ${this.device.connectionType} Connection, Error Message: ${JSON.stringify(e.message)}`)
-              await this.BLEPushConnection()
-            })
+            this.successLog(`On: ${this.On} sent over SwitchBot BLE, sent successfully`)
+            await this.updateHomeKitCharacteristics()
+          } catch (e: any) {
+            await this.apiError(e)
+            if (botPassword && !isDiscoveryTimeoutError(e)) {
+              this.errorLog(`Bot BLE password command failed for ${this.device.deviceId}. Verify password and BLE response.`)
+            }
+            if (isDiscoveryTimeoutError(e)) {
+              this.errorLog(`Bot BLE discovery failed for ${this.device.deviceId}. Device was not discovered before timeout.`)
+            }
+            this.errorLog(`failed BLEpushChanges with ${this.device.connectionType} Connection, Error Message: ${JSON.stringify(e.message)}`)
+            await this.BLEPushConnection()
+          }
         } else {
           this.errorLog(`Device Parameters not set for this Bot, please check the device configuration. Bot Mode: ${this.botMode}`)
         }
       } catch (error) {
         this.errorLog(`failed to format device ID as MAC, Error: ${error}`)
+      } finally {
+        if (shouldPausePlatformScan) {
+          try {
+            await switchBotBLE.startScan()
+            this.debugLog('Resumed platform BLE scanning after password Bot command execution.')
+          } catch (e: any) {
+            this.errorLog(`Failed to resume platform BLE scanning: ${e.message ?? e}`)
+          }
+        }
       }
     } else {
       this.debugLog(`No Changes (BLEpushChanges), On: ${this.On} OnCached: ${this.accessory.context.On}`)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -91,6 +91,7 @@ export interface botConfig extends BaseDeviceConfig {
   configDeviceType: 'Bot'
   mode?: string
   type: string
+  password?: string
   doublePress?: number
   pushRatePress?: number
   allowPush?: boolean

--- a/src/utils.bot-ble.test.ts
+++ b/src/utils.bot-ble.test.ts
@@ -1,0 +1,31 @@
+import { Buffer } from 'node:buffer'
+
+import { describe, expect, it } from 'vitest'
+
+import { buildBotBleCommand, validateBotPassword } from './utils.js'
+
+describe('Bot BLE helpers', () => {
+  it('builds plain Bot BLE command bytes without password', () => {
+    expect(buildBotBleCommand(0x00)).toEqual(Buffer.from([0x57, 0x01, 0x00]))
+    expect(buildBotBleCommand(0x01)).toEqual(Buffer.from([0x57, 0x01, 0x01]))
+    expect(buildBotBleCommand(0x02)).toEqual(Buffer.from([0x57, 0x01, 0x02]))
+  })
+
+  it('builds encrypted Bot BLE command bytes with password', () => {
+    expect(buildBotBleCommand(0x01, 'A1b2')).toEqual(Buffer.from([0x57, 0x11, 0xB8, 0x59, 0x37, 0x46, 0x01]))
+    expect(buildBotBleCommand(0x01, 'A1b2').length).toBe(7)
+  })
+
+  it('validates password format', () => {
+    expect(() => validateBotPassword('A1b2')).not.toThrow()
+    expect(() => validateBotPassword('abc')).toThrow()
+    expect(() => validateBotPassword('abcde')).toThrow()
+    expect(() => validateBotPassword('ab!2')).toThrow()
+  })
+
+  it('uses case-sensitive CRC32 for password bytes', () => {
+    const upper = buildBotBleCommand(0x00, 'Ab1C')
+    const lower = buildBotBleCommand(0x00, 'ab1c')
+    expect(upper.equals(lower)).toBe(false)
+  })
+})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@
  * util.ts: @switchbot/homebridge-switchbot platform class.
  */
 import type { blindTilt, curtain, curtain3, device } from 'node-switchbot'
+import { Buffer } from 'node:buffer'
 
 import type { devicesConfig } from './settings.js'
 
@@ -111,6 +112,55 @@ export function formatDeviceIdAsMac(deviceId: string, cassSensative?: boolean): 
   }
 
   throw new Error(`Invalid device ID format. Must be a valid MAC address, a 12-character hexadecimal string, or a 12 to 18-character alphanumeric string. Device ID: ${deviceId}`)
+}
+
+const BOT_BLE_ACTION_VALUES = [0x00, 0x01, 0x02] as const
+type BotBleAction = (typeof BOT_BLE_ACTION_VALUES)[number]
+
+const CRC32_POLYNOMIAL = 0xEDB88320
+const CRC32_TABLE = new Uint32Array(256)
+
+for (let i = 0; i < 256; i++) {
+  let crc = i
+  for (let j = 0; j < 8; j++) {
+    crc = (crc & 1) !== 0 ? (crc >>> 1) ^ CRC32_POLYNOMIAL : (crc >>> 1)
+  }
+  CRC32_TABLE[i] = crc >>> 0
+}
+
+function crc32(input: string): number {
+  let crc = 0xFFFFFFFF
+  for (let i = 0; i < input.length; i++) {
+    const byte = input.charCodeAt(i)
+    crc = (crc >>> 8) ^ CRC32_TABLE[(crc ^ byte) & 0xFF]
+  }
+  return (crc ^ 0xFFFFFFFF) >>> 0
+}
+
+export function validateBotPassword(password: string): void {
+  if (!/^[A-Za-z0-9]{4}$/.test(password)) {
+    throw new Error('Invalid Bot password. Password must be exactly 4 alphanumeric characters (case-sensitive).')
+  }
+}
+
+export function buildBotBleCommand(action: BotBleAction, password?: string): Buffer {
+  if (!BOT_BLE_ACTION_VALUES.includes(action)) {
+    throw new Error(`Invalid Bot BLE action: ${action}. Expected one of 0x00, 0x01, or 0x02.`)
+  }
+  if (!password) {
+    return Buffer.from([0x57, 0x01, action])
+  }
+  validateBotPassword(password)
+  const crc = crc32(password)
+  return Buffer.from([
+    0x57,
+    0x11,
+    (crc >>> 24) & 0xFF,
+    (crc >>> 16) & 0xFF,
+    (crc >>> 8) & 0xFF,
+    crc & 0xFF,
+    action,
+  ])
 }
 
 export function rgb2hs(r: any, g: any, b: any) {


### PR DESCRIPTION
## :recycle: Current situation

This fixes https://github.com/OpenWonderLabs/homebridge-switchbot/issues/604 and https://github.com/OpenWonderLabs/homebridge-switchbot/issues/45

---

SwitchBot Bot devices configured with a BLE password could not be controlled via this plugin over BLE.

Root causes:
1. `homebridge-switchbot` had no Bot password config path and always used plain Bot commands (`0x57 0x01 ...`).
2. `node-switchbot` does not currently expose password-Bot command helpers, so the plugin had no built-in encrypted Bot command API.
3. In BLE command flow, Bot control depends on discovery before command send. With password-protected Bots, discovery was intermittently unreliable in real environments, causing command path failures before write.

Symptoms seen by users:
- Bot commands failing over BLE when password is enabled.
- Discovery timeout errors (`No SwitchBot devices found after ...`) and unstable connect/service discovery in some setups.

## :bulb: Proposed solution

This PR adds Bot BLE password support in `homebridge-switchbot` (plugin-side) without requiring immediate `node-switchbot` changes.

### Main changes

1. **Bot password config**
- Added `password?: string` to Bot device config type.
- Added `options.devices[].password` to schema/UI for Bot devices using BLE/BLE+OpenAPI.
- Scope is intentionally per-device only (no global Bot password field).

2. **Encrypted Bot BLE command path**
- Added local helpers:
  - `validateBotPassword(password)`
  - `buildBotBleCommand(action, password?)`
- Password rule: exactly 4 alphanumeric chars, case-sensitive.
- Command format:
  - No password: `0x57 0x01 action`
  - With password: `0x57 0x11 CRC32(password_be) action`
- CRC32 is implemented locally (table-driven) to avoid adding runtime deps for a small deterministic operation.

3. **BLE execution flow updates for password Bots**
- Added direct command execution helper for Bot BLE actions with response validation.
- Added address-first discovery behavior and scan-collision mitigation for password Bot command execution to improve reliability in noisy BLE environments.
- Improved error classification/logging so discovery failures are distinct from password command failures.

4. **Docs/tests**
- README updated with Bot password BLE guidance.
- Added unit tests for command building/password validation and Bot BLE action path.

### Why plugin-side first (instead of `node-switchbot` now)

This is a focused user-facing fix with minimal dependency churn for this plugin release.  
Long-term, parts of this could be moved into `node-switchbot` (e.g., first-class password Bot command API + discovery compatibility improvements), but this PR unblocks users immediately.

## :gear: Release Notes

- Added BLE password support for SwitchBot Bot commands (per-device config).
- Added Bot password field in device config for BLE/BLE+OpenAPI Bot devices.
- Improved BLE command reliability for password-protected Bots in environments with concurrent scanning.
- Improved logging to better differentiate discovery vs command failures.

Breaking changes: **none**.

Migration:
- For protected Bots, set `password` in the specific Bot device config (4 alphanumeric chars, case-sensitive).
- No changes required for Bots without password.

## :heavy_plus_sign: Additional Information

### Testing

Added:
- `src/utils.bot-ble.test.ts`
  - plain command bytes
  - encrypted command shape/bytes
  - password validation rules
  - case sensitivity behavior
- `src/device/bot.ble-password.test.ts`
  - legacy path without password (`press/turnOn/turnOff`)
  - encrypted `command(Buffer)` path with password
  - invalid password rejection
  - invalid response handling

Existing tests:
- `src/index.test.ts` unchanged and still passing.

Coverage notes / remaining edge cases:
- BLE reliability behavior is partially environment-dependent (adapter/driver/Noble timing).
- Hardware-in-the-loop validation for multiple Bot firmware variants remains advisable.

### Reviewer Nudging

Suggested review order:
1. `src/device/bot.ts` (core behavior + fallback/reliability logic)
2. `src/utils.ts` (password validation + command generation/CRC32)
3. `src/settings.ts` + `config.schema.json` (config exposure)
4. `src/utils.bot-ble.test.ts` and `src/device/bot.ble-password.test.ts` (behavioral expectations)
5. `README.md` (user-facing config guidance)