### PR TITLE
fix: water detector device mapping, HAP cache deserialization crash, and slow leak reads

### DIFF
--- a/src/SwitchBotHAPPlatform.ts
+++ b/src/SwitchBotHAPPlatform.ts
@@ -240,12 +240,38 @@ export class SwitchBotHAPPlatform {
             // ignore
           }
         }
+        // Ensure AccessoryInformation service exists - required for cache deserialization.
+        // Without it, hap-nodejs _sideloadServices crashes on next start.
+        try {
+          const InfoService = hap.Service.AccessoryInformation
+          if (InfoService) {
+            const info = accessory.getService(InfoService) || accessory.addService(InfoService)
+            const accDescForInfo = await created.createAccessory?.(this.api).catch?.(() => undefined)
+            const manufacturer = (accDescForInfo && accDescForInfo.manufacturer) || 'SwitchBot'
+            const model = (accDescForInfo && accDescForInfo.model) || type || 'SwitchBot Device'
+            const serial = (accDescForInfo && accDescForInfo.serialNumber) || d.id
+            const firmware = (accDescForInfo && accDescForInfo.firmwareRevision) || '1.0.0'
+            try {
+              info.setCharacteristic(hap.Characteristic.Manufacturer, manufacturer)
+              info.setCharacteristic(hap.Characteristic.Model, model)
+              info.setCharacteristic(hap.Characteristic.SerialNumber, serial)
+              info.setCharacteristic(hap.Characteristic.FirmwareRevision, firmware)
+            } catch (e) {
+              // ignore
+            }
+          }
+        } catch (e) {
+          // ignore
+        }
         // Add basic service descriptor from device (symmetrical to Matter: remove stale services/chars)
         const accDesc = await created.createAccessory?.(this.api)
         if (accDesc && accDesc.services) {
           const serviceTypes = accDesc.services.map((s: any) => s.type)
           for (const existingService of accessory.services.slice()) {
-            if (existingService.constructor && existingService.constructor.name && !serviceTypes.includes(existingService.constructor.name)) {
+            // Never remove AccessoryInformation - required for cache deserialization
+            if (existingService.constructor && existingService.constructor.name
+              && existingService.constructor.name !== 'AccessoryInformation'
+              && !serviceTypes.includes(existingService.constructor.name)) {
               accessory.removeService(existingService)
             }
           }

--- a/src/deviceFactory.ts
+++ b/src/deviceFactory.ts
@@ -109,6 +109,7 @@ const DEVICE_CLASS_MAP: Record<string, any> = {
   'meter': MeterDevice,
   'meter plus (jp)': MeterDevice,
   'water detector': WaterDetectorDevice,
+  'waterdetector': WaterDetectorDevice,
   'smart fan': SmartFanDevice,
   'strip light': StripLightDevice,
   'wosweeper': WoSweeperDevice,

--- a/src/devices/genericDevice.ts
+++ b/src/devices/genericDevice.ts
@@ -1306,6 +1306,100 @@ export class MeterDevice extends GenericDevice {
 }
 
 export class WaterDetectorDevice extends GenericDevice {
+  private _leakRefreshing = false
+  private _leakRefreshTs = 0
+  private lastLeakDetected?: boolean
+  private readonly LEAK_REFRESH_TTL_MS = 30_000
+
+  async init(): Promise<void> {
+    await super.init()
+    await this._refreshLeakState(!this.client)
+  }
+
+  private normalizeLeakDetected(state: any): boolean | undefined {
+    if (typeof state?.leak === 'boolean') {
+      return state.leak
+    }
+    if (typeof state?.waterLeakDetected === 'boolean') {
+      return state.waterLeakDetected
+    }
+    if (typeof state?.body?.waterLeakDetected === 'boolean') {
+      return state.body.waterLeakDetected
+    }
+    const status = state?.status ?? state?.body?.status
+    if (typeof status === 'number') {
+      return status === 1
+    }
+    if (typeof status === 'string') {
+      return ['1', 'leak', 'leaked', 'detected', 'water_leak_detected'].includes(status.toLowerCase())
+    }
+    return undefined
+  }
+
+  private async readLeakDetectedFromOpenAPI(): Promise<boolean | undefined> {
+    const token = this.cfg?.openApiToken
+    const secret = this.cfg?.openApiSecret
+    if (!token || !secret) {
+      return undefined
+    }
+
+    try {
+      const { OpenAPIClient } = await import('node-switchbot')
+      const apiClient = new OpenAPIClient(token, secret)
+      return this.normalizeLeakDetected(await apiClient.getStatus(this.opts.id))
+    } catch (e) {
+      this.log?.debug?.(`[WaterDetector] direct OpenAPI leak refresh failed: ${(e as Error)?.message}`)
+    }
+
+    return undefined
+  }
+
+  private async readLeakDetected(fallbackToDeviceState = true): Promise<boolean | undefined> {
+    const openApiLeak = await this.readLeakDetectedFromOpenAPI()
+    if (typeof openApiLeak === 'boolean') {
+      return openApiLeak
+    }
+    if (!fallbackToDeviceState) {
+      return undefined
+    }
+
+    try {
+      return this.normalizeLeakDetected(await this.getState())
+    } catch (e) {
+      this.log?.debug?.(`[WaterDetector] leak refresh failed: ${(e as Error)?.message}`)
+    }
+
+    return undefined
+  }
+
+  private async _refreshLeakState(fallbackToDeviceState = true): Promise<void> {
+    if (this._leakRefreshing) {
+      return
+    }
+    this._leakRefreshing = true
+    try {
+      const leakDetected = await this.readLeakDetected(fallbackToDeviceState)
+      if (typeof leakDetected === 'boolean') {
+        this.lastLeakDetected = leakDetected
+        this._leakRefreshTs = Date.now()
+      }
+    } catch (e) {
+      this.log?.debug?.(`[WaterDetector] leak refresh failed: ${(e as Error)?.message}`)
+    } finally {
+      this._leakRefreshing = false
+    }
+  }
+
+  private getLeakDetectedFast(api: any): number {
+    if (Date.now() - this._leakRefreshTs >= this.LEAK_REFRESH_TTL_MS) {
+      this._refreshLeakState().catch(() => undefined)
+    }
+    if (typeof this.lastLeakDetected === 'boolean') {
+      return this.lastLeakDetected ? 1 : 0
+    }
+    throw new api.hap.HapStatusError(api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
+  }
+
   createHAPAccessory(api: any) {
     return {
       services: [
@@ -1313,10 +1407,7 @@ export class WaterDetectorDevice extends GenericDevice {
           type: 'LeakSensor',
           characteristics: {
             LeakDetected: {
-              get: async () => {
-                const s = await this.getState()
-                return s && s.leak ? 1 : 0
-              },
+              get: () => this.getLeakDetectedFast(api),
             },
           },
         },

--- a/test/device/deviceFactory.spec.ts
+++ b/test/device/deviceFactory.spec.ts
@@ -30,4 +30,13 @@ describe('createDevice', () => {
     const result = await createDevice({ id: 'xyz', type: 'UnknownType' }, dummyConfig as any, false)
     expect(result.instance.constructor.name).toBe('GenericDevice')
   })
+
+  it('should create a WaterDetectorDevice for normalized "waterdetector" type', async () => {
+    // normalizeTypeForMatter() returns 'waterdetector' (no space) for water detector variants.
+    // This regression test ensures the no-space key is mapped so devices aren't silently
+    // downgraded to GenericDevice (which would expose a bogus Switch service).
+    const result = await createDevice({ id: 'wd1', type: 'waterdetector' }, dummyConfig as any, false)
+    expect(result.instance).toBeDefined()
+    expect(result.instance.constructor.name).toBe('WaterDetectorDevice')
+  })
 })

--- a/test/device/water-detector-leak.spec.ts
+++ b/test/device/water-detector-leak.spec.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+
+import { WaterDetectorDevice } from '../../src/devices/genericDevice'
+
+const mockLogger = { info: () => {}, warn: () => {}, error: () => {}, debug: () => {} }
+
+const mockApi = {
+  hap: {
+    HapStatusError: class HapStatusError extends Error {
+      constructor(public status: number) {
+        super(`HAP status ${status}`)
+      }
+    },
+    HAPStatus: {
+      SERVICE_COMMUNICATION_FAILURE: -70402,
+    },
+  },
+}
+
+describe('WaterDetectorDevice leak state', () => {
+  it('warms leak state and serves LeakDetected synchronously from cache', async () => {
+    let reads = 0
+    const device = new WaterDetectorDevice({ id: 'wd1', type: 'waterdetector' }, { log: mockLogger })
+    device.getState = async () => {
+      reads += 1
+      return { waterLeakDetected: true }
+    }
+
+    await device.init()
+    const leakDetected = device.createHAPAccessory(mockApi).services[0].characteristics.LeakDetected.get()
+
+    expect(leakDetected).toBe(1)
+    expect(leakDetected).not.toBeInstanceOf(Promise)
+    expect(reads).toBe(1)
+  })
+
+  it('throws a HAP communication failure instead of blocking when no leak state is cached', () => {
+    const device = new WaterDetectorDevice({ id: 'wd1', type: 'waterdetector' }, { log: mockLogger })
+    device.getState = async () => ({ waterLeakDetected: false })
+
+    expect(() => device.createHAPAccessory(mockApi).services[0].characteristics.LeakDetected.get()).toThrow('HAP status -70402')
+  })
+})


### PR DESCRIPTION
## :recycle: Current situation

Two related fixes that together resolve the water detector being completely broken in v5 (showing as a generic Switch in HomeKit and crashing the child bridge with TypeError on restart).

## :bulb: Proposed solution

1. `deviceFactory`: register `'waterdetector'` (no-space) mapping alongside the existing 'water detector' entry.

   normalizeTypeForMatter() in utils.ts returns 'waterdetector' (no space) for water detector variants, but DEVICE_CLASS_MAP only had 'water detector' (with space) as a key. Since the HAP platform passes the type through normalizeTypeForMatter() before calling createDevice(), the lookup missed and water detectors fell back to GenericDevice - which exposes a Switch/On service. This caused:
   - Wrong service type in HomeKit (Switch instead of LeakSensor)
   - 'read handler for the characteristic On was slow' warnings
   - Cache deserialization crash on next start

   Adds 'waterdetector' to mirror the existing convention used for other
   normalized variants (e.g. 'roller shade' + 'rollershade',
   'wo rollershade' + 'worollershade').

Discovered with test code

```ts
this.log.warn('[HAP Debug] api exists:', !!this.api);
this.log.warn('[HAP Debug] api.hap exists:', !!(this.api && this.api.hap));
this.log.warn('[HAP Debug] typeof api.registerPlatformAccessories:', typeof (this.api && this.api.registerPlatformAccessories));
this.log.warn('[HAP Debug] typeof api.hap.registerPlatformAccessories:', typeof (this.api && this.api.hap && this.api.hap.registerPlatformAccessories));
this.log.warn('[HAP Debug] typeof api.platformAccessory:', typeof (this.api && this.api.platformAccessory));
this.log.warn('[HAP Debug] createdDevices count:', createdDevices.length);
```

```
api exists: true
api.hap exists: true
typeof api.registerPlatformAccessories: function
typeof api.hap.registerPlatformAccessories: undefined
typeof api.platformAccessory: function
createdDevices count: 1
```

2. SwitchBotHAPPlatform: add AccessoryInformation service before registration, and protect it from the stale-service cleanup pass.

   Without an AccessoryInformation service in the cached accessory, hap-nodejs Accessory._sideloadServices() crashes with 'Cannot read properties of undefined (reading getCharacteristic)' when Homebridge tries to deserialize the cached accessory on restart.

Full error:
```
TypeError: Cannot read properties of undefined (reading 'getCharacteristic')
  at Accessory._sideloadServices
  at Accessory.deserialize
  at PlatformAccessory.deserialize
  at BridgeService.loadCachedPlatformAccessoriesFromDisk
```

3. Also fixes Homebridge slow-read warnings for the Water Detector `Leak Detected` characteristic by serving HomeKit reads from cached leak state instead of awaiting live device status.

>  ❯ [26/05/2026, 18:22:51] [@switchbot/homebridge-switchbot] This plugin slows down Homebridge. The read handler for the characteristic 'Leak Detected' was slow to respond! See https://homebridge.io/w/JtMGR for more info.                        

## :gear: Release Notes

`fix: water detector device mapping, HAP cache deserialization crash`

### Testing

- Tested on my Homebridge 2.0.x instance
- Added test in `test/device/deviceFactory.spec.ts`


### Reviewer Nudging



Note: 

```ts
  'water detector': WaterDetectorDevice, // <-- I think this one is dead, remove, or keep redundant?
  'waterdetector': WaterDetectorDevice,
```