### PR TITLE
fix: restore Battery service for water detector

### DIFF
--- a/src/devices/genericDevice.ts
+++ b/src/devices/genericDevice.ts
@@ -1306,6 +1306,137 @@ export class MeterDevice extends GenericDevice {
 }
 
 export class WaterDetectorDevice extends GenericDevice {
+  private lastBatteryLevel?: number
+  private _batteryRefreshing = false
+  private _batteryRefreshTs = 0
+  private readonly BATTERY_REFRESH_TTL_MS = 30_000
+
+  constructor(opts: any, cfg: any) {
+    super(opts, cfg)
+  }
+
+  async init(): Promise<void> {
+    await super.init()
+    await this._refreshBattery()
+  }
+
+  private normalizeBatteryLevel(state: any): number | undefined {
+    const raw = state?.battery ?? state?.body?.battery
+    if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+      return undefined
+    }
+    return Math.max(0, Math.min(100, raw))
+  }
+
+  private async getSwitchBotDevice(): Promise<any> {
+    const managedDevice = (this.client as any)?.client?.devices?.get?.(this.opts.id)
+    if (managedDevice) {
+      return managedDevice
+    }
+    return await (this.client as any)?.getDevice?.(this.opts.id)
+  }
+
+  private async readBatteryLevelFromOpenAPI(): Promise<number | undefined> {
+    const token = this.cfg?.openApiToken
+    const secret = this.cfg?.openApiSecret
+    if (!token || !secret) {
+      return undefined
+    }
+
+    try {
+      const { OpenAPIClient } = await import('node-switchbot')
+      const apiClient = new OpenAPIClient(token, secret)
+      const status = await apiClient.getStatus(this.opts.id)
+      return this.normalizeBatteryLevel(status)
+    } catch (e) {
+      this.log?.debug?.(`[WaterDetector] direct OpenAPI battery refresh failed: ${(e as Error)?.message}`)
+    }
+
+    return undefined
+  }
+
+  private async readBatteryLevel(): Promise<number | undefined> {
+    const openApiBattery = await this.readBatteryLevelFromOpenAPI()
+    if (typeof openApiBattery === 'number') {
+      return openApiBattery
+    }
+
+    const device = await this.getSwitchBotDevice()
+    if (!device) {
+      return undefined
+    }
+
+    if (typeof device.apiClient?.getStatus === 'function') {
+      try {
+        const rawApiStatus = await device.apiClient.getStatus(device.info?.id ?? this.opts.id)
+        const battery = this.normalizeBatteryLevel(rawApiStatus)
+        if (typeof battery === 'number') {
+          return battery
+        }
+      } catch (e) {
+        this.log?.debug?.(`[WaterDetector] apiClient battery refresh failed: ${(e as Error)?.message}`)
+      }
+    }
+
+    if (typeof device.getAPIStatus === 'function') {
+      try {
+        const apiStatus = await device.getAPIStatus()
+        const battery = this.normalizeBatteryLevel(apiStatus)
+        if (typeof battery === 'number') {
+          return battery
+        }
+      } catch (e) {
+        this.log?.debug?.(`[WaterDetector] getAPIStatus battery refresh failed: ${(e as Error)?.message}`)
+      }
+    }
+
+    try {
+      if (typeof device.getStatus === 'function') {
+        const status = await device.getStatus()
+        const battery = this.normalizeBatteryLevel(status)
+        if (typeof battery === 'number') {
+          return battery
+        }
+      }
+    } catch (e) {
+      this.log?.debug?.(`[WaterDetector] getStatus battery refresh failed: ${(e as Error)?.message}`)
+    }
+
+    return undefined
+  }
+
+  private async _refreshBattery(): Promise<void> {
+    if (this._batteryRefreshing) {
+      return
+    }
+    this._batteryRefreshing = true
+    try {
+      const battery = await this.readBatteryLevel()
+      if (typeof battery === 'number') {
+        this.lastBatteryLevel = battery
+        this._batteryRefreshTs = Date.now()
+      }
+    } catch (e) {
+      this.log?.debug?.(`[WaterDetector] battery refresh failed: ${(e as Error)?.message}`)
+    } finally {
+      this._batteryRefreshing = false
+    }
+  }
+
+  // Returns the cached battery level immediately and triggers a background
+  // refresh if the cache is stale. Throws HapStatusError on true cold start
+  // so HomeKit shows "Not Available" rather than fabricating a misleading
+  // value or timing out (which surfaces as 0% in the Home app).
+  private getBatteryFast(api: any): number {
+    if (Date.now() - this._batteryRefreshTs >= this.BATTERY_REFRESH_TTL_MS) {
+      this._refreshBattery().catch(() => undefined)
+    }
+    if (typeof this.lastBatteryLevel === 'number') {
+      return this.lastBatteryLevel
+    }
+    throw new api.hap.HapStatusError(api.hap.HAPStatus.SERVICE_COMMUNICATION_FAILURE)
+  }
+
   createHAPAccessory(api: any) {
     return {
       services: [
@@ -1317,6 +1448,23 @@ export class WaterDetectorDevice extends GenericDevice {
                 const s = await this.getState()
                 return s && s.leak ? 1 : 0
               },
+            },
+          },
+        },
+        {
+          type: 'Battery',
+          characteristics: {
+            BatteryLevel: {
+              get: () => this.getBatteryFast(api),
+            },
+            StatusLowBattery: {
+              get: () => {
+                const b = this.getBatteryFast(api)
+                return b < 20 ? 1 : 0
+              },
+            },
+            ChargingState: {
+              get: () => 2,
             },
           },
         },

--- a/test/device/water-detector-battery.spec.ts
+++ b/test/device/water-detector-battery.spec.ts
@@ -1,0 +1,80 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { WaterDetectorDevice } from '../../src/devices/genericDevice'
+
+const openApiMocks = vi.hoisted(() => {
+  const getStatus = vi.fn()
+  return {
+    getStatus,
+    OpenAPIClient: vi.fn().mockImplementation(function () {
+      return { getStatus }
+    }),
+  }
+})
+
+vi.mock('node-switchbot', () => ({
+  OpenAPIClient: openApiMocks.OpenAPIClient,
+}))
+
+const mockLogger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+
+const mockApi = {
+  hap: {
+    HapStatusError: class HapStatusError extends Error {
+      constructor(readonly status: number) {
+        super(`HAP ${status}`)
+      }
+    },
+    HAPStatus: {
+      SERVICE_COMMUNICATION_FAILURE: -70402,
+    },
+  },
+}
+
+function makeDevice(config: Record<string, unknown> = {}) {
+  return new WaterDetectorDevice(
+    { id: 'wd1', type: 'waterdetector', name: 'Fridge', log: mockLogger, blePollingEnabled: false },
+    { log: mockLogger, openApiToken: 'token', openApiSecret: 'secret', ...config } as any,
+  )
+}
+
+function getBatteryService(device: WaterDetectorDevice) {
+  const accessory = device.createHAPAccessory(mockApi)
+  return accessory.services.find((service: any) => service.type === 'Battery')
+}
+
+describe('WaterDetectorDevice battery service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    openApiMocks.getStatus.mockResolvedValue({ battery: 87 })
+  })
+
+  it('adds a Battery service to the HAP accessory descriptor', () => {
+    const batteryService = getBatteryService(makeDevice())
+
+    expect(batteryService).toBeDefined()
+    expect(batteryService.characteristics.BatteryLevel).toBeDefined()
+    expect(batteryService.characteristics.StatusLowBattery).toBeDefined()
+    expect(batteryService.characteristics.ChargingState).toBeDefined()
+  })
+
+  it('warms the battery cache from direct OpenAPI status', async () => {
+    const device = makeDevice()
+
+    await device.init()
+
+    const batteryService = getBatteryService(device)
+    expect(openApiMocks.OpenAPIClient).toHaveBeenCalledWith('token', 'secret')
+    expect(openApiMocks.getStatus).toHaveBeenCalledWith('wd1')
+    expect(batteryService.characteristics.BatteryLevel.get()).toBe(87)
+    expect(batteryService.characteristics.StatusLowBattery.get()).toBe(0)
+    expect(batteryService.characteristics.ChargingState.get()).toBe(2)
+  })
+
+  it('does not fabricate a battery level before one is cached', () => {
+    const device = makeDevice({ openApiSecret: undefined })
+    const batteryService = getBatteryService(device)
+
+    expect(() => batteryService.characteristics.BatteryLevel.get()).toThrow('HAP -70402')
+  })
+})


### PR DESCRIPTION
## :recycle: Current situation

The v5.0.0 rewrite (#1357) replaced the dedicated per-device files with a single declarative genericDevice.ts. In that rewrite, only the primary service for each device was re-wired. The Water Detector's Battery service from v4 was dropped.

The SwitchBot Water Leak Detector reports battery via the OpenAPI 'battery' state field, so HomeKit low-battery alerts are useful and were expected behavior in v4.

## :bulb: Proposed solution

1. Restores BatteryLevel, StatusLowBattery (threshold <20%), and ChargingState (not chargeable) characteristics on the LeakSensor accessory.

2. Also avoids Homebridge slow-read warnings for the Battery characteristics by caching the battery level and returning it synchronously from `BatteryLevel` / `StatusLowBattery`.

>  [26/05/2026, 18:22:51] [@switchbot/homebridge-switchbot] This plugin slows down Homebridge. The read handler for the characteristic 'Battery Level' was slow to respond! See https://homebridge.io/w/JtMGR for more info.                        
> [26/05/2026, 18:22:51] [@switchbot/homebridge-switchbot] This plugin slows down Homebridge. The read handler for the characteristic 'Status Low Battery' was slow to respond! See https://homebridge.io/w/JtMGR for more info.                   
 
The cache is warmed from the SwitchBot OpenAPI status endpoint during device init and refreshed in the background, so HomeKit reads do not block on a live API call.

<img width="370" height="228" alt="image" src="https://github.com/user-attachments/assets/ba35955a-c21b-4153-8e0f-e55b57668599" />


## :gear: Release Notes

`fix(battery-regression): restore Battery service for leak sensor`

## :heavy_plus_sign: Additional Information

n/a

### Testing

 - Added unit coverage for the WaterDetector Battery service descriptor
 - Verified BatteryLevel / StatusLowBattery read from the cached OpenAPI battery value
 - Verified missing battery does not fabricate a fake value
 - Manually tested on Homebridge v2.0.2: Fridge Water Detector reports 100% battery and no Battery slow-read warnings

### Reviewer Nudging

review the battery fetching logic