### PR TITLE
Make Bot HomeKit switch stateless

### DIFF
--- a/src/devices/genericDevice.ts
+++ b/src/devices/genericDevice.ts
@@ -480,7 +480,25 @@ export class GenericDevice extends DeviceBase {
 }
 
 // Specific device classes can extend GenericDevice for custom behavior.
-export class BotDevice extends GenericDevice {}
+export class BotDevice extends GenericDevice {
+  createHAPAccessory(api: any): any {
+    return {
+      services: [
+        {
+          type: 'Switch',
+          characteristics: {
+            On: {
+              get: async () => false,
+              set: async () => {
+                await this.setState({ command: 'press', parameter: 'default', commandType: 'command' })
+              },
+            },
+          },
+        },
+      ],
+    }
+  }
+}
 
 export class CurtainDevice extends GenericDevice {
   createHAPAccessory(api: any) {


### PR DESCRIPTION
## Summary

- Makes SwitchBot Bot HomeKit accessories behave like stateless press buttons while still exposing the familiar Switch service.
- Keeps the HomeKit `On` characteristic reporting `false` so every tap can generate a write.
- Sends the SwitchBot `press` command for any HomeKit `On` write, whether HomeKit writes `true` or `false`.

## Root Cause

Bot accessories are momentary actuators, but HomeKit Switch is stateful. If the accessory behaves like a normal on/off switch, the Bot only presses when HomeKit transitions from off to on; a following on-to-off tap can be ignored or mapped to an off command instead of another press.

## Changes

- Adds a Bot-specific HAP accessory descriptor.
- The Bot Switch `On` getter always returns `false`.
- The Bot Switch `On` setter always sends `{ command: "press", parameter: "default", commandType: "command" }`.
- Leaves other generic device switch behavior unchanged.

## Validation

- `npm run lint`
- `npm run build`
- `npm test`

## Notes

- This is the Homebridge/HomeKit behavior layer. The companion BLE library fix is OpenWonderLabs/node-switchbot#334.
