### PR TITLE
Fix Curtain HomeKit BLE state handling

### DIFF
--- a/src/SwitchBotHAPPlatform.ts
+++ b/src/SwitchBotHAPPlatform.ts
@@ -304,7 +304,26 @@ export class SwitchBotHAPPlatform {
                 service.getCharacteristic(Characteristic).onGet(getterSetter.get)
               }
               if (getterSetter && typeof getterSetter.set === 'function') {
-                service.getCharacteristic(Characteristic).onSet(getterSetter.set)
+                service.getCharacteristic(Characteristic).onSet(async (value: any) => {
+                  await getterSetter.set(value)
+
+                  const refreshAfterSet = Array.isArray(getterSetter.refreshAfterSet) ? getterSetter.refreshAfterSet : []
+                  for (const refreshCharName of refreshAfterSet) {
+                    const refreshGetterSetter: any = (s.characteristics || {})[refreshCharName]
+                    if (!refreshGetterSetter || typeof refreshGetterSetter.get !== 'function') {
+                      continue
+                    }
+                    const RefreshCharacteristic = (hap.Characteristic as any)[refreshCharName]
+                    if (!RefreshCharacteristic) {
+                      continue
+                    }
+                    try {
+                      service.getCharacteristic(RefreshCharacteristic).updateValue(await refreshGetterSetter.get())
+                    } catch (e) {
+                      this.log.debug?.(`Failed to refresh ${refreshCharName} after setting ${charName}`, e)
+                    }
+                  }
+                })
               }
             }
           }

--- a/src/devices/genericDevice.ts
+++ b/src/devices/genericDevice.ts
@@ -483,6 +483,38 @@ export class GenericDevice extends DeviceBase {
 export class BotDevice extends GenericDevice {}
 
 export class CurtainDevice extends GenericDevice {
+  private lastKnownPosition = 0
+  private lastTargetPosition = 0
+  private positionState = 2
+  private preferLocalPositionUntil = 0
+
+  private clampHomeKitPosition(position: number): number {
+    return Math.max(0, Math.min(100, Math.round(Number(position))))
+  }
+
+  private toHomeKitPosition(switchBotPosition: number): number {
+    return 100 - this.clampHomeKitPosition(switchBotPosition)
+  }
+
+  private toSwitchBotPosition(homeKitPosition: number): number {
+    return 100 - this.clampHomeKitPosition(homeKitPosition)
+  }
+
+  private async getPositionForHomeKit(): Promise<number> {
+    if (Date.now() < this.preferLocalPositionUntil) {
+      return this.lastKnownPosition
+    }
+    const state = await Promise.race([
+      this.getState(),
+      new Promise(resolve => setTimeout(() => resolve(undefined), 1000)),
+    ])
+    if (typeof state?.position === 'number') {
+      this.lastKnownPosition = this.toHomeKitPosition(Number(state.position))
+      this.lastTargetPosition = this.lastKnownPosition
+    }
+    return this.lastKnownPosition
+  }
+
   createHAPAccessory(api: any) {
     return {
       services: [
@@ -491,18 +523,27 @@ export class CurtainDevice extends GenericDevice {
           characteristics: {
             CurrentPosition: {
               get: async () => {
-                const s = await this.getState()
-                return typeof s.position === 'number' ? s.position : 0
+                return this.getPositionForHomeKit()
               },
+            },
+            PositionState: {
+              get: async () => this.positionState,
             },
             TargetPosition: {
               get: async () => {
-                const s = await this.getState()
-                return typeof s.position === 'number' ? s.position : 0
+                await this.getPositionForHomeKit()
+                return this.lastTargetPosition
               },
               set: async (v: any) => {
-                await this.setState({ position: Number(v) })
+                const position = this.clampHomeKitPosition(Number(v))
+                this.lastTargetPosition = position
+                this.positionState = position > this.lastKnownPosition ? 1 : position < this.lastKnownPosition ? 0 : 2
+                await this.setState({ position: this.toSwitchBotPosition(position) })
+                this.lastKnownPosition = position
+                this.preferLocalPositionUntil = Date.now() + 30000
+                this.positionState = 2
               },
+              refreshAfterSet: ['CurrentPosition', 'TargetPosition', 'PositionState'],
             },
           },
         },


### PR DESCRIPTION
## Summary

- translate SwitchBot Curtain BLE positions to HomeKit WindowCovering positions
- add `PositionState` handling for Curtain accessories
- refresh explicit WindowCovering characteristics after writes so HomeKit settles on the stopped/current state

## Why

SwitchBot Curtain BLE reports `0 = open`, while HomeKit WindowCovering expects `0 = closed`. That made HomeKit show the wrong motion direction and sometimes leave Curtain tiles stuck in an in-progress state after the motor finished moving.

## Validation

- `npm run build`
- `npm test` (`23 passed | 1 skipped`, `74 passed | 1 skipped`)
- live-tested Curtain 3 motors through HomeKit/HAP on the Mac mini using the same source changes in the fork build
