### PR TITLE
feat(bot): add botMode: "press" option for momentary-button behavior

### DIFF
--- a/src/SwitchBotHAPPlatform.ts
+++ b/src/SwitchBotHAPPlatform.ts
@@ -2,6 +2,7 @@ import type { SwitchBotPluginConfig } from './settings.js'
 import type { API, Logger, PlatformConfig } from 'homebridge'
 
 import { createDevice } from './deviceFactory.js'
+import { BotDevice } from './devices/genericDevice.js'
 import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js'
 import { SwitchBotClient } from './switchbotClient.js'
 import { normalizeTypeForMatter } from './utils.js'
@@ -152,7 +153,7 @@ export class SwitchBotHAPPlatform {
         _raw: raw,
       }
       const type: string = normalizeTypeForMatter(d.type)
-      const deviceOpts: any = { id: d.id, type, name: d.name, encryptionKey: d.encryptionKey, keyId: d.keyId, log: this.log }
+      const deviceOpts: any = { id: d.id, type, name: d.name, encryptionKey: d.encryptionKey, keyId: d.keyId, log: this.log, botMode: raw.botMode }
       this.log.debug(`[HAP/Debug] Device options for ${d.name ?? d.id}:`, JSON.stringify(deviceOpts, null, 2))
       try {
         const created = await createDevice(deviceOpts, this.config, false)
@@ -305,6 +306,9 @@ export class SwitchBotHAPPlatform {
               }
               if (getterSetter && typeof getterSetter.set === 'function') {
                 service.getCharacteristic(Characteristic).onSet(getterSetter.set)
+                if (created instanceof BotDevice && charName === 'On') {
+                  created._hapOnChar = service.getCharacteristic(Characteristic)
+                }
               }
             }
           }

--- a/src/devices/genericDevice.ts
+++ b/src/devices/genericDevice.ts
@@ -480,7 +480,40 @@ export class GenericDevice extends DeviceBase {
 }
 
 // Specific device classes can extend GenericDevice for custom behavior.
-export class BotDevice extends GenericDevice {}
+export class BotDevice extends GenericDevice {
+  /** HAP On characteristic reference, set by SwitchBotHAPPlatform after registration. */
+  _hapOnChar: any = null
+
+  createHAPAccessory(api: any) {
+    if ((this.opts as any).botMode !== 'press') {
+      return super.createHAPAccessory(api)
+    }
+    // Press mode: tap-to-trigger with automatic reset. Sends a single "press"
+    // command and resets the On characteristic to false after 1 second so the
+    // tile in the Home app behaves like a momentary button rather than a toggle.
+    return {
+      services: [
+        {
+          type: 'Switch',
+          characteristics: {
+            On: {
+              get: async () => false,
+              set: async (v: any) => {
+                if (!v) return
+                await this.setState({ command: 'press', parameter: 'default', commandType: 'command' })
+                setTimeout(() => {
+                  if (this._hapOnChar) {
+                    this._hapOnChar.updateValue(false)
+                  }
+                }, 1000)
+              },
+            },
+          },
+        },
+      ],
+    }
+  }
+}
 
 export class CurtainDevice extends GenericDevice {
   createHAPAccessory(api: any) {


### PR DESCRIPTION
## Summary

- Adds an optional `botMode: "press"` per-device config field for Bot accessories
- When set, tapping the tile sends a single `press` command (not `turnOn`/`turnOff`) and the `On` characteristic auto-resets to `false` after 1 second
- Default behavior (`botMode` omitted or `"switch"`) is unchanged

## Motivation

A SwitchBot Bot used to toggle a physical momentary button (e.g. a coffee machine power button) doesn't have meaningful on/off state. Without this option, HomeKit shows the tile as a persistent toggle — the user must manually turn it off after each press, and same-accessory automations to auto-reset are blocked by HomeKit.

With `botMode: "press"` the tile behaves like a button: tap it, the bot presses, the tile snaps back to off automatically.

## Config example

```json
{
  "deviceId": "DE6443C6502B",
  "configDeviceName": "Espresso Machine",
  "configDeviceType": "Bot",
  "botMode": "press"
}
```

## Implementation notes

- `BotDevice.createHAPAccessory` is overridden; when `botMode !== "press"` it falls through to `super.createHAPAccessory` so existing behavior is fully preserved
- `SwitchBotHAPPlatform.registerHAPAccessories` stores the HAP `On` characteristic on the `BotDevice` instance after `onSet` registration, so the 1-second reset timer can call `characteristic.updateValue(false)` without needing a platform reference
- TypeScript compiles cleanly with `tsc --noEmit`

## Test plan

- [ ] Bot with no `botMode` set: on/off toggle works as before
- [ ] Bot with `botMode: "press"`: tapping on in Home app fires `press` command, tile resets to off within ~1 second
- [ ] Bot with `botMode: "press"`: tapping off (briefly visible during the reset window) is a no-op

🤖 Generated with [Claude Code](https://claude.com/claude-code)