### PR TITLE
Fix lint: prefer-timer-args and test title/callback fixes

### DIFF
--- a/src/devices/genericDevice.ts
+++ b/src/devices/genericDevice.ts
@@ -506,7 +506,7 @@ export class CurtainDevice extends GenericDevice {
     }
     const state = await Promise.race([
       this.getState(),
-      new Promise(resolve => setTimeout(() => resolve(undefined), 1000)),
+      new Promise(resolve => setTimeout(resolve, 1000)),
     ])
     if (typeof state?.position === 'number') {
       this.lastKnownPosition = this.toHomeKitPosition(Number(state.position))

--- a/test/device/water-detector-battery.spec.ts
+++ b/test/device/water-detector-battery.spec.ts
@@ -6,9 +6,8 @@ const openApiMocks = vi.hoisted(() => {
   const getStatus = vi.fn()
   return {
     getStatus,
-    OpenAPIClient: vi.fn().mockImplementation(function () {
-      return { getStatus }
-    }),
+    OpenAPIClient: vi.fn().mockImplementation(() => ({ getStatus })),
+
   }
 })
 
@@ -43,7 +42,7 @@ function getBatteryService(device: WaterDetectorDevice) {
   return accessory.services.find((service: any) => service.type === 'Battery')
 }
 
-describe('WaterDetectorDevice battery service', () => {
+describe('water detector device battery service', () => {
   beforeEach(() => {
     vi.clearAllMocks()
     openApiMocks.getStatus.mockResolvedValue({ battery: 87 })

--- a/test/device/water-detector-battery.spec.ts
+++ b/test/device/water-detector-battery.spec.ts
@@ -6,7 +6,9 @@ const openApiMocks = vi.hoisted(() => {
   const getStatus = vi.fn()
   return {
     getStatus,
-    OpenAPIClient: vi.fn().mockImplementation(() => ({ getStatus })),
+    // Use a function implementation so the mock is constructible with `new OpenAPIClient()`
+    // eslint-disable-next-line prefer-arrow-callback
+    OpenAPIClient: vi.fn().mockImplementation(function () { return { getStatus } }),
 
   }
 })

--- a/test/device/water-detector-leak.spec.ts
+++ b/test/device/water-detector-leak.spec.ts
@@ -17,7 +17,7 @@ const mockApi = {
   },
 }
 
-describe('WaterDetectorDevice leak state', () => {
+describe('water detector device leak state', () => {
   it('warms leak state and serves LeakDetected synchronously from cache', async () => {
     let reads = 0
     const device = new WaterDetectorDevice({ id: 'wd1', type: 'waterdetector' }, { log: mockLogger })


### PR DESCRIPTION
Run eslint --fix on tests and genericDevice to resolve e18e/prefer-timer-args and test naming rules. Co-authored-by: Copilot App <223556219+Copilot@users.noreply.github.com>