### PR TITLE
fix: return a device status from getState(), not the device itself

### DIFF
--- a/src/deviceFactory.ts
+++ b/src/deviceFactory.ts
@@ -177,20 +177,10 @@ export async function createDevice(opts: DeviceOptions, cfg: SwitchBotPluginConf
   const device = new DeviceCtor(deviceOpts, mergedCfg)
   await device.init()
 
-  // Attach a simple getState delegator to the client where appropriate
-  const originalGetState = device.getState.bind(device)
-  device.getState = async () => {
-    try {
-      // Prefer client-backed getDevice when available
-      const dev = await client.getDevice(opts.id)
-      if (dev) {
-        return dev
-      }
-    } catch (e) {
-      // ignore and fallback to device implementation
-    }
-    return originalGetState()
-  }
+  // No getState() override here: the device's own implementation already
+  // prefers the client-backed lookup, and it converts the result into a status.
+  // An override that returned the client device directly shadowed it, and that
+  // object carries no readings.
 
   // Provide accessory factory based on platform selection
   return {

--- a/src/devices/genericDevice.ts
+++ b/src/devices/genericDevice.ts
@@ -201,9 +201,21 @@ export class GenericDevice extends DeviceBase {
         // Normalize common response shapes
         try {
           const device = raw?.body ?? raw
-          return device
-        } catch (e) {
-          return raw
+          // node-switchbot returns a device instance, not a status. The instance
+          // exposes id/name/deviceType/mac but carries no readings, so a caller
+          // reading state.temperature would get undefined. Ask it for status.
+          if (device && typeof device.getStatus === 'function') {
+            const status = await device.getStatus()
+            if (status && typeof status === 'object') {
+              return status
+            }
+            // Fall through to the minimal info below rather than returning the
+            // instance, which would look like a state with every field missing.
+          } else {
+            return device
+          }
+        } catch (e: any) {
+          this.log?.debug?.(`getState: could not read status for ${this.opts.id}:`, e instanceof Error ? e.message : e)
         }
       } catch (e) {
         // ignore and fallback

--- a/test/device/getstate-returns-status.spec.ts
+++ b/test/device/getstate-returns-status.spec.ts
@@ -1,0 +1,89 @@
+/* Copyright(C) 2021-2026, donavanbecker (https://github.com/donavanbecker). All rights reserved.
+ *
+ * getstate-returns-status.spec.ts: getState() must yield readings, not the device
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+
+import { createDevice } from '../../src/deviceFactory.js'
+import { GenericDevice, MeterDevice } from '../../src/devices/genericDevice.js'
+
+const log: any = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn(), success: vi.fn() }
+
+/** A node-switchbot style device: identity on the instance, readings via getStatus(). */
+function switchBotDevice(status: any) {
+  return {
+    id: 'B0E9FED044E3',
+    name: 'Meter Pro CO2 Monitor',
+    deviceType: 'MeterPro(CO2)',
+    mac: 'b0:e9:fe:d0:44:e3',
+    getStatus: async () => status,
+  }
+}
+
+const STATUS = { deviceId: 'B0E9FED044E3', temperature: 23.7, humidity: 59, battery: 100, connectionType: 'api' }
+
+function deviceWith(client: any) {
+  return new GenericDevice({ id: 'B0E9FED044E3', type: 'meter', name: 'Meter', log }, { log, _client: client } as any)
+}
+
+describe('genericDevice.getState', () => {
+  it('returns the status rather than the device instance', async () => {
+    const state = await deviceWith({ getDevice: async () => switchBotDevice(STATUS) }).getState()
+
+    expect(state).toEqual(STATUS)
+    expect(state.temperature).toBe(23.7)
+    expect(state.humidity).toBe(59)
+  })
+
+  it('passes through a plain status object unchanged', async () => {
+    const state = await deviceWith({ getDevice: async () => ({ temperature: 20, humidity: 40 }) }).getState()
+
+    expect(state).toEqual({ temperature: 20, humidity: 40 })
+  })
+
+  it('unwraps an API-shaped body', async () => {
+    const state = await deviceWith({ getDevice: async () => ({ body: { temperature: 19 } }) }).getState()
+
+    expect(state).toEqual({ temperature: 19 })
+  })
+
+  it.each([
+    ['throws', async () => { throw new Error('unreachable') }],
+    ['returns null', async () => null],
+  ])('reports minimal info when getStatus() %s', async (_label, getStatus) => {
+    const client = { getDevice: async () => ({ ...switchBotDevice(STATUS), getStatus }) }
+
+    const state = await deviceWith(client).getState()
+
+    // Not the device instance: that would look like a reading of every field.
+    expect(state).toEqual({ id: 'B0E9FED044E3', type: 'meter' })
+    expect(state.temperature).toBeUndefined()
+  })
+})
+
+describe('createDevice', () => {
+  it('does not replace the device getState with the raw client device', async () => {
+    const client = { init: async () => {}, getDevice: async () => switchBotDevice(STATUS) }
+    const created: any = await createDevice(
+      { id: 'B0E9FED044E3', type: 'meter', name: 'Meter', log } as any,
+      { log, _client: client } as any,
+      false,
+    )
+
+    const state = await created.instance.getState()
+
+    expect(state.temperature).toBe(23.7)
+    expect(state.getStatus).toBeUndefined()
+  })
+
+  it('lets a meter report a real temperature end to end', async () => {
+    const client = { init: async () => {}, getDevice: async () => switchBotDevice(STATUS) }
+    const device = new MeterDevice({ id: 'B0E9FED044E3', type: 'meter', name: 'Meter', log } as any, { log, _client: client } as any)
+
+    const services = device.createHAPAccessory(null).services
+    const temperature = services.find((s: any) => s.type === 'TemperatureSensor')
+
+    await expect(temperature.characteristics.CurrentTemperature.get()).resolves.toBe(23.7)
+  })
+})


### PR DESCRIPTION
Fixes #1403

`getState()` returned the node-switchbot device instance rather than that
device's status, so every characteristic getter read a field that is not on it
and fell back to a default. HomeKit received a plausible `0`, or 100% battery,
with nothing logged.

### What changed

- `src/devices/genericDevice.ts` — when the object from `client.getDevice()` can
  report status, `await device.getStatus()` and return that. Objects that are
  already a plain status, and `{ body }` responses, behave as before. A device
  that reports no status falls back to the existing minimal `{ id, type }`
  rather than the instance, since the instance looks like a state whose every
  field happens to be missing.
- `src/deviceFactory.ts` — drop the `getState` override. It set an instance
  property that shadowed the class implementation, so fixing the class alone had
  no effect at runtime. The class already prefers the client-backed lookup.

### Tests

`test/device/getstate-returns-status.spec.ts` covers: a status is returned
rather than the instance; plain status objects and `{ body }` responses still
pass through; a failing or empty `getStatus()` yields minimal info instead of the
instance; `createDevice()` no longer replaces the method; and a meter reports a
real temperature through `createHAPAccessory()`.

Full suite, lint, typecheck and build pass.

### Verified on hardware

Meter Pro (CO2), values pushed to HomeKit before:

```
CurrentTemperature=23.7, CurrentRelativeHumidity=0, BatteryLevel=100,
StatusLowBattery=0, CarbonDioxideLevel=0
```

after:

```
CurrentTemperature=23.7, CurrentRelativeHumidity=59, BatteryLevel=100,
StatusLowBattery=0, CarbonDioxideLevel=403
```

### Scope

Deliberately limited to the one defect. I found several adjacent issues while
tracking this down — including CO2 never being exposed for the Meter Pro (CO2),
polled values being fetched then discarded, and two `node-switchbot` problems —
and I would rather offer those separately than bundle them here.
